### PR TITLE
Upgrade dev container to use Debian Bullseye

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,19 +1,12 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.178.0/containers/typescript-node/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/typescript-node/.devcontainer/base.Dockerfile
 
-# [Choice] Node.js version: 16, 14, 12
-ARG VARIANT="16-buster"
+# [Choice] Node.js version: 18, 16, 14
+ARG VARIANT="16-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
 
-# install recent python version.
-ARG PYTHON_VERSION="3.9"
-RUN export DEBIAN_FRONTEND=noninteractive \
-    && echo "deb http://http.us.debian.org/debian/ testing non-free contrib main" >> \
-        /etc/apt/sources.list \
-    && apt update -y \
-    && apt install -y python${PYTHON_VERSION} python3-pip \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.9 10 \
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 10
-    
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.178.0/containers/typescript-node
 {
-	"name": "Python 3",
+	"name": "Data Portal UI",
 
 	"dockerComposeFile": [
 		// the main compose file containing all data portal services,
@@ -42,5 +42,9 @@
 	// "postCreateCommand": "yarn install",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node"
+	"remoteUser": "node",
+
+	"features": {
+		"python": "3.10"
+	}
 }


### PR DESCRIPTION
Solves a problem when installing Python 3.9 under Buster.

Also we now use the dev container built-in features to install Python instead of installing it manually.