### PR TITLE
Add config with HSTS for production

### DIFF
--- a/configure_build_serve/run.py
+++ b/configure_build_serve/run.py
@@ -11,9 +11,8 @@ To get help run:
     ./run.py --help
 """
 
-import os
-import sys
 import argparse
+import os
 from pathlib import Path
 from typing import Optional
 from subprocess import Popen
@@ -108,7 +107,9 @@ def serve(config: Config):
         "--no-clipboard",
         "--listen",
         f"tcp://{config.host}:{config.port}",
-        "-s",
+        "--single",
+        "--config",
+        "../configure_build_serve/serve.json",
         str(ROOT_DIR / "build"),
     ]
     exit_code_serve = Popen(cmd_serve).wait()

--- a/configure_build_serve/serve.json
+++ b/configure_build_serve/serve.json
@@ -1,0 +1,9 @@
+{
+    "headers": [{
+        "source": "!.well-known/**",
+        "headers": [{
+            "key": "Strict-Transport-Security",
+            "value": "max-age=31536000"
+        }]
+    }]
+}


### PR DESCRIPTION
Currently, the UI is served via both http and both https. In the former case, a warning will appear and all data will be sent unencrypted over the network. Also, LS Login will not work because it requires the https based client URL.

This can be fixed by configuring the API gateway to send a redirect for http requests and/or by sending an HSTS (HTTP Strict Transport Security) header with the application. This PR implements the latter. It adds a serve.json configuration file that adds a HSTS header, but can also be used for [other purposes](https://github.com/vercel/serve-handler#options).