### PR TITLE
Avoid duplicate requests and redirects

### DIFF
--- a/src/components/login/callback.tsx
+++ b/src/components/login/callback.tsx
@@ -5,10 +5,16 @@ import authService from "../../services/auth";
 
 /** Handle redirect after OIDC login */
 
+let calls = 0;
+
 const Callback = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
+
+    // make sure token request and redirection happen only once
+    // (even in development with strict mode activated)
+    if (calls++) return;
 
     const handleError = () => {
       alert("Could not log in.");  // TODO: make nicer


### PR DESCRIPTION
The requests and redirects after hitting the callback page should happen only once.

However, since we have [Strict Mode](https://reactjs.org/docs/strict-mode.html) activated (which is useful and therefore should not be just deactivated), every component is rendered twice in development mode. So we need to safeguard the `useEffect` function against running twice.