### PR TITLE
Add helpers for showing uniform user messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,23 @@
 # production
 /build
 
-# misc
-.DS_Store
-**/*.env
+# compiled Pyhton files
+__pycache__/
+*.py[cod]
+
+# environment files
+*.env
 
 # test certificate
 *.pem
 
 # log files
 npm-debug.log*
+
+# ignore VS Code settings
+.vscode/
+
+# desktop settings and thumbnails
+.DS_Store
+desktop.ini
+thumbs.db

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "data-portal-ui",
       "version": "0.1.0",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "~6.2.0",
-        "@fortawesome/free-brands-svg-icons": "~6.2.0",
-        "@fortawesome/free-regular-svg-icons": "~6.2.0",
-        "@fortawesome/free-solid-svg-icons": "~6.2.0",
+        "@fortawesome/fontawesome-svg-core": "~6.4.0",
+        "@fortawesome/free-brands-svg-icons": "~6.4.0",
+        "@fortawesome/free-regular-svg-icons": "~6.4.0",
+        "@fortawesome/free-solid-svg-icons": "~6.4.0",
         "@fortawesome/react-fontawesome": "~0.2.0",
         "@popperjs/core": "~2.11.6",
         "@testing-library/dom": "~8.17.1",
@@ -40,7 +40,8 @@
         "sass": "~1.56.0",
         "swiper": "~8.3.2",
         "typescript": "~4.8.4",
-        "web-vitals": "~3.0.1"
+        "web-vitals": "~3.0.1",
+        "zustand": "~4.3.7"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2314,57 +2315,57 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
-      "integrity": "sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.1.tgz",
-      "integrity": "sha512-HELwwbCz6C1XEcjzyT1Jugmz2NNklMrSPjZOWMlc+ZsHIVk+XOvOXLGGQtFBwSyqfJDNgRq4xBCwWOaZ/d9DEA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+      "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.2.1"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-brands-svg-icons": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.2.1.tgz",
-      "integrity": "sha512-L8l4MfdHPmZlJ72PvzdfwOwbwcCAL0vx48tJRnI6u1PJXh+j2f3yDoKyQgO3qjEsgD5Fr2tQV/cPP8F/k6aUig==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-qvxTCo0FQ5k2N+VCXb/PZQ+QMhqRVM4OORiO6MXdG6bKolIojGU/srQ1ptvKk0JTbRgaJOfL2qMqGvBEZG7Z6g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.2.1"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-regular-svg-icons": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.2.1.tgz",
-      "integrity": "sha512-wiqcNDNom75x+pe88FclpKz7aOSqS2lOivZeicMV5KRwOAeypxEYWAK/0v+7r+LrEY30+qzh8r2XDaEHvoLsMA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.2.1"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.1.tgz",
-      "integrity": "sha512-oKuqrP5jbfEPJWTij4sM+/RvgX+RMFwx3QZCZcK9PrBDgxC35zuc7AOFsyMjMd/PIFPeB2JxyqDr5zs/DZFPPw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.2.1"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       },
       "engines": {
         "node": ">=6"
@@ -16235,6 +16236,14 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -17229,6 +17238,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.7.tgz",
+      "integrity": "sha512-dY8ERwB9Nd21ellgkBZFhudER8KVlelZm8388B5nDAXhO/+FZDhYMuRnqDgu5SYyRgz/iaf8RKnbUs/cHfOGlQ==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   },
@@ -18716,40 +18748,40 @@
       "integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg=="
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
-      "integrity": "sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ=="
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.1.tgz",
-      "integrity": "sha512-HELwwbCz6C1XEcjzyT1Jugmz2NNklMrSPjZOWMlc+ZsHIVk+XOvOXLGGQtFBwSyqfJDNgRq4xBCwWOaZ/d9DEA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+      "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "6.2.1"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       }
     },
     "@fortawesome/free-brands-svg-icons": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.2.1.tgz",
-      "integrity": "sha512-L8l4MfdHPmZlJ72PvzdfwOwbwcCAL0vx48tJRnI6u1PJXh+j2f3yDoKyQgO3qjEsgD5Fr2tQV/cPP8F/k6aUig==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-qvxTCo0FQ5k2N+VCXb/PZQ+QMhqRVM4OORiO6MXdG6bKolIojGU/srQ1ptvKk0JTbRgaJOfL2qMqGvBEZG7Z6g==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "6.2.1"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       }
     },
     "@fortawesome/free-regular-svg-icons": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.2.1.tgz",
-      "integrity": "sha512-wiqcNDNom75x+pe88FclpKz7aOSqS2lOivZeicMV5KRwOAeypxEYWAK/0v+7r+LrEY30+qzh8r2XDaEHvoLsMA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "6.2.1"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       }
     },
     "@fortawesome/free-solid-svg-icons": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.1.tgz",
-      "integrity": "sha512-oKuqrP5jbfEPJWTij4sM+/RvgX+RMFwx3QZCZcK9PrBDgxC35zuc7AOFsyMjMd/PIFPeB2JxyqDr5zs/DZFPPw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "6.2.1"
+        "@fortawesome/fontawesome-common-types": "6.4.0"
       }
     },
     "@fortawesome/react-fontawesome": {
@@ -28894,6 +28926,12 @@
         "requires-port": "^1.0.0"
       }
     },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -29667,6 +29705,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zustand": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.7.tgz",
+      "integrity": "sha512-dY8ERwB9Nd21ellgkBZFhudER8KVlelZm8388B5nDAXhO/+FZDhYMuRnqDgu5SYyRgz/iaf8RKnbUs/cHfOGlQ==",
+      "requires": {
+        "use-sync-external-store": "1.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "~6.2.0",
-    "@fortawesome/free-brands-svg-icons": "~6.2.0",
-    "@fortawesome/free-regular-svg-icons": "~6.2.0",
-    "@fortawesome/free-solid-svg-icons": "~6.2.0",
+    "@fortawesome/fontawesome-svg-core": "~6.4.0",
+    "@fortawesome/free-brands-svg-icons": "~6.4.0",
+    "@fortawesome/free-regular-svg-icons": "~6.4.0",
+    "@fortawesome/free-solid-svg-icons": "~6.4.0",
     "@fortawesome/react-fontawesome": "~0.2.0",
     "@popperjs/core": "~2.11.6",
     "@testing-library/dom": "~8.17.1",
@@ -35,7 +35,8 @@
     "react-twitter-embed": "~4.0.4",
     "swiper": "~8.3.2",
     "typescript": "~4.8.4",
-    "web-vitals": "~3.0.1"
+    "web-vitals": "~3.0.1",
+    "zustand": "~4.3.7"
   },
   "resolutions": {
     "react-error-overlay": "6.0.9"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,8 @@ import MetadataModel from "./components/metadataModel/metadataModel";
 import Callback from "./components/login/callback";
 import Register from "./components/register/register";
 import Profile from "./components/login/profile";
+import { MessageContainer } from "./components/messages/container";
+import { useMessages } from "./components/messages/usage";
 import authService from "./services/auth";
 import { useLayoutEffect } from "react";
 
@@ -51,6 +53,7 @@ const router = createBrowserRouter(
 function Layout() {
   let location = useLocation();
   const navigate = useNavigate();
+  const { showMessage } = useMessages();
 
   useLayoutEffect(() => {
     authService
@@ -67,9 +70,10 @@ function Layout() {
         }
       })
       .catch((error) => {
+        showMessage({ type: "error", title: "Cannot login" });
         console.error(error);
       });
-  }, [location, navigate]);
+  }, [location, navigate, showMessage]);
 
   return (
     <>
@@ -78,6 +82,7 @@ function Layout() {
       </header>
       <main>
         <Outlet />
+        <MessageContainer />
       </main>
       <footer>
         <Footer />

--- a/src/api/browse.ts
+++ b/src/api/browse.ts
@@ -1,10 +1,22 @@
-import { searchResponseModel, datasetEmbeddedModel, datasetDetailsSummaryModel, metadataSummaryModel } from "../models/dataset";
+import {
+  searchResponseModel,
+  datasetEmbeddedModel,
+  datasetDetailsSummaryModel,
+  metadataSummaryModel,
+} from "../models/dataset";
 import { facetFilterModel } from "../models/facets";
 import { fetchJson } from "../utils/utils";
-
+import { showMessage } from "../components/messages/usage";
 
 const SEARCH_URL = process.env.REACT_APP_SVC_SEARCH_URL;
 const REPOSITORY_URL = process.env.REACT_APP_SVC_REPOSITORY_URL;
+
+const showFetchDataError = () => {
+  showMessage({
+    type: "error",
+    title: "An error occurred while fetching the data.",
+  });
+};
 
 type getDatasetsSearchRespType = (
   callbackFunc: (hits: searchResponseModel) => void,
@@ -15,8 +27,8 @@ type getDatasetsSearchRespType = (
   documentType: string
 ) => void;
 
-/** 
- * Async function to retrieve the search results from API, calls the callbackFunc 
+/**
+ * Async function to retrieve the search results from API, calls the callbackFunc
  * function with search results, returns nothing.
  * @param callbackFunc - Function takes an argument conforms to the searchResponseModel.
  * @param filterQuery - Filters to be applied, array of objects that conform to the facetFilterModel.
@@ -41,15 +53,16 @@ export const querySearchService: getDatasetsSearchRespType = async (
     const response = await fetchJson(url, "POST", payload);
     const data = await response.json();
     callbackFunc(data);
-  } catch {
-    alert("An error occurred while fetching the data.");
+  } catch (error) {
+    showFetchDataError();
+    console.log(error);
     const errorData: searchResponseModel = {
       count: -1,
       hits: [],
       facets: [],
     };
     callbackFunc(errorData);
-  };
+  }
 };
 
 type getDatasetDetailsType = (
@@ -59,7 +72,7 @@ type getDatasetDetailsType = (
 ) => void;
 
 /**
- * Async function to retrieve the details of specified dataset from API, 
+ * Async function to retrieve the details of specified dataset from API,
  * calls the callbackFunc function with the response data, returns nothing.
  * @param datasetId - ID of the dataset of interest.
  * @param embedded - Boolean for the url parameter "embedded". Default: 'false'.
@@ -77,8 +90,9 @@ export const getDatasetDetails: getDatasetDetailsType = async (
     const response = await fetchJson(url);
     const data = await response.json();
     callbackFunc(data);
-  } catch {
-    alert("An error occurred while fetching the data.");
+  } catch (error) {
+    showFetchDataError();
+    console.log(error);
   }
 };
 
@@ -87,9 +101,8 @@ type getDatasetSummaryType = (
   callbackFunc: (dataset: datasetDetailsSummaryModel) => void
 ) => void;
 
-
 /**
- * Async function to retrieve the summary of specified dataset from API, 
+ * Async function to retrieve the summary of specified dataset from API,
  * calls the callbackFunc function with the response data, returns nothing.
  * @param datasetId - ID of the dataset of interest.
  * @param callbackFunc - Function used to process response data.
@@ -104,9 +117,10 @@ export const getDatasetSummary: getDatasetSummaryType = async (
     const response = await fetchJson(url);
     const data = await response.json();
     callbackFunc(data);
-  } catch {
-    alert("An error occurred while fetching the data.");
-  };
+  } catch (error) {
+    showFetchDataError();
+    console.log(error);
+  }
 };
 
 type getMetadataSummaryType = (
@@ -114,27 +128,23 @@ type getMetadataSummaryType = (
 ) => void;
 
 /**
- * Async function to retrieve the metadata summary from API, 
+ * Async function to retrieve the metadata summary from API,
  * calls the callbackFunc function with the response data, returns nothing.
  * @param callbackFunc - Function used to process response data.
  * @returns Nothing
  */
-export const getMetadataSummary: getMetadataSummaryType = (
-  callbackFunc
-) => {
-  fetch(
-    `${process.env.REACT_APP_SVC_REPOSITORY_URL}/metadata_summary/`,
-    {
-      method: "get",
-    }
-  )
+export const getMetadataSummary: getMetadataSummaryType = (callbackFunc) => {
+  fetch(`${process.env.REACT_APP_SVC_REPOSITORY_URL}/metadata_summary/`, {
+    method: "get",
+  })
     .then((response) => response.json())
     .then(
       (data) => {
         callbackFunc(data);
       },
       (error) => {
-        alert("An error occured while fetching the data.");
+        showFetchDataError();
+        console.log(error);
       }
     );
 };

--- a/src/components/login/callback.tsx
+++ b/src/components/login/callback.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Col, Container, Row, Spinner } from "react-bootstrap";
 import authService from "../../services/auth";
+import { useMessages } from "../messages/usage";
 
 /** Handle redirect after OIDC login */
 
@@ -9,6 +10,7 @@ let calls = 0;
 
 const Callback = () => {
   const navigate = useNavigate();
+  const { showMessage } = useMessages();
 
   const [searchParams] = useSearchParams();
   const state = searchParams.get("state");
@@ -19,7 +21,7 @@ const Callback = () => {
     if (calls++) return;
 
     const handleError = () => {
-      alert("Could not log in."); // TODO: make nicer
+      showMessage({ type: "error", title: "Could not log in" });
       const lastUrl = sessionStorage.getItem("lastUrl");
       lastUrl ? (window.location.href = lastUrl) : navigate("/");
     };
@@ -29,8 +31,7 @@ const Callback = () => {
       // since the cookie might be wrong if you try to access the
       // page directly, just send them back to the previous page
       navigate(-1);
-    }
-    else {
+    } else {
       authService
         .callback()
         .then((user) => {
@@ -46,11 +47,12 @@ const Callback = () => {
           }
         })
         .catch((error) => {
+          showMessage({ type: "error", title: "Cannot login" });
           console.error(error);
           handleError();
         });
     }
-  }, [navigate, state]);
+  }, [navigate, state, showMessage]);
 
   return (
     <Container className="mt-4">

--- a/src/components/messages/container.tsx
+++ b/src/components/messages/container.tsx
@@ -1,0 +1,71 @@
+// Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+// for the German Human Genome-Phenome Archive (GHGA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import ToastContainer from "react-bootstrap/ToastContainer";
+import { ModalMessage } from "./modal";
+import { ToastMessage } from "./toast";
+import { useMessages } from "./usage";
+
+export const MessageContainer = () => {
+  const { getModal, getToasts } = useMessages();
+
+  let modalMessage = null;
+  const modal = getModal();
+  if (modal) {
+    modalMessage = (
+      <ModalMessage
+        id={modal.id}
+        key={modal.id}
+        type={modal.type}
+        title={modal.title}
+        detail={modal.detail}
+        callback1={modal.callback1}
+        label1={modal.label1}
+        callback2={modal.callback2}
+        label2={modal.label2}
+      ></ModalMessage>
+    );
+  }
+  let toastMessages = null;
+  const toasts = getToasts();
+  if (toasts) {
+    toastMessages = (
+      <ToastContainer
+        position="top-center"
+        containerPosition="fixed"
+        style={{ margin: 6 }}
+      >
+        {toasts.map((toast) => (
+          <ToastMessage
+            id={toast.id}
+            key={toast.id}
+            type={toast.type}
+            title={toast.title}
+            detail={toast.detail}
+            delay={toast.delay}
+          ></ToastMessage>
+        ))}
+      </ToastContainer>
+    );
+  }
+
+  return (
+    <>
+      {modalMessage}
+      {toastMessages}
+    </>
+  );
+};

--- a/src/components/messages/modal.tsx
+++ b/src/components/messages/modal.tsx
@@ -1,0 +1,101 @@
+// Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+// for the German Human Genome-Phenome Archive (GHGA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { useState } from "react";
+import Button from "react-bootstrap/Button";
+import Modal from "react-bootstrap/Modal";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useMessages } from "./usage";
+import { MessageType, messageStyles } from "./styles";
+
+const Z_INDEX = 9999; // should be above toast messages
+
+export type ModalMessageProps = {
+  id?: number;
+  type?: MessageType;
+  title?: string;
+  detail?: string;
+  callback1?: () => void;
+  label1?: string;
+  callback2?: () => void;
+  label2?: string;
+};
+
+// modal that is used by the system wide message container
+// (but can also be used inside a component on any page)
+
+export function ModalMessage(props: ModalMessageProps) {
+  const [show, setShow] = useState(true);
+  const { dismissMessage: dismiss } = useMessages();
+
+  const handleClose = () => {
+    setShow(false);
+    if (props.id !== undefined) {
+      dismiss(props.id);
+    }
+  };
+
+  const messageStyle = messageStyles[props.type || "success"];
+  const title = props.title || messageStyle.title;
+  const { icon, iconClass } = messageStyle;
+
+  const body = props.detail ? <Modal.Body>{props.detail}</Modal.Body> : null;
+  const { callback1, callback2 } = props;
+  const handleButton1 = () => {
+    callback1 && callback1();
+    handleClose();
+  };
+  const button1 = (
+    <Button variant="primary" onClick={handleButton1}>
+      {props.label1 || "OK"}
+    </Button>
+  );
+  let button2 = null;
+  if (callback2) {
+    const handleButton2 = () => {
+      callback2();
+      handleClose();
+    };
+    button2 = (
+      <Button variant="secondary" onClick={handleButton2}>
+        {props.label2 || "Cancel"}
+      </Button>
+    );
+  }
+
+  return (
+    <Modal
+      show={show}
+      onHide={handleClose}
+      centered={true}
+      style={{ zIndex: Z_INDEX }}
+    >
+      <Modal.Header closeButton>
+        <FontAwesomeIcon
+          icon={icon}
+          size="2x"
+          className={iconClass + " me-3"}
+        />
+        <Modal.Title>{title}</Modal.Title>
+      </Modal.Header>
+      {body}
+      <Modal.Footer>
+        {button2}
+        {button1}
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/components/messages/styles.ts
+++ b/src/components/messages/styles.ts
@@ -1,0 +1,55 @@
+// Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+// for the German Human Genome-Phenome Archive (GHGA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import {
+  faInfoCircle,
+  faCheckCircle,
+  faExclamationTriangle,
+  faTimesCircle,
+  IconDefinition,
+} from "@fortawesome/free-solid-svg-icons";
+
+export type MessageType = "info" | "warning" | "success" | "error";
+
+export const messageStyles: Record<
+  MessageType,
+  { title: string; icon: IconDefinition; iconClass: string; bg: string }
+> = {
+  info: {
+    title: "Note",
+    icon: faInfoCircle,
+    iconClass: "text-info",
+    bg: "info",
+  },
+  success: {
+    title: "Success",
+    icon: faCheckCircle,
+    iconClass: "text-success",
+    bg: "success",
+  },
+  warning: {
+    title: "Warning",
+    icon: faExclamationTriangle,
+    iconClass: "text-warning",
+    bg: "warning",
+  },
+  error: {
+    title: "Error",
+    icon: faTimesCircle,
+    iconClass: "text-danger",
+    bg: "danger",
+  },
+};

--- a/src/components/messages/toast.tsx
+++ b/src/components/messages/toast.tsx
@@ -1,0 +1,85 @@
+// Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+// for the German Human Genome-Phenome Archive (GHGA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { CSSProperties, useState } from "react";
+import Toast from "react-bootstrap/Toast";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useMessages } from "./usage";
+import { MessageType, messageStyles } from "./styles";
+
+const DEFAULT_DELAY = 5000; // 5 seconds
+
+export type ToastMessageProps = {
+  id?: number;
+  type?: MessageType;
+  title?: string;
+  detail?: string;
+  delay?: number;
+};
+
+// toast that is used by the system wide message container
+// (but can also be used inside a component on any page)
+
+export const ToastMessage = (props: ToastMessageProps) => {
+  const [show, setShow] = useState(true);
+  const { dismissMessage: dismiss } = useMessages();
+
+  const handleClose = () => {
+    setShow(false);
+    if (props.id !== undefined) {
+      dismiss(props.id);
+    }
+  };
+
+  const messageStyle = messageStyles[props.type || "success"];
+  const title = props.title || messageStyle.title;
+  const { icon, iconClass, bg } = messageStyle;
+
+  let { delay } = props;
+  if (delay === undefined) {
+    // 0 or null can be used for sticky toasts (no autohide)
+    delay = DEFAULT_DELAY;
+  }
+  const autohide = !!delay;
+
+  const body = props.detail ? <Toast.Body>{props.detail}</Toast.Body> : null;
+  const headerStyle: CSSProperties = {};
+  if (!body) {
+    // without body, the header should be rounded at the bottom as well
+    headerStyle.borderRadius =
+      "calc(var(--bs-toast-border-radius) - var(--bs-toast-border-width))";
+  }
+
+  return (
+    <Toast
+      show={show}
+      onClose={handleClose}
+      bg={bg}
+      autohide={autohide}
+      delay={delay}
+    >
+      <Toast.Header style={headerStyle}>
+        <FontAwesomeIcon
+          icon={icon}
+          size="2x"
+          className={iconClass + " me-3"}
+        />
+        <strong className="ms-3 me-auto">{title}</strong>
+      </Toast.Header>
+      {body}
+    </Toast>
+  );
+};

--- a/src/components/messages/usage.ts
+++ b/src/components/messages/usage.ts
@@ -1,0 +1,95 @@
+// Copyright 2021 - 2023 Universität Tübingen, DKFZ and EMBL
+// for the German Human Genome-Phenome Archive (GHGA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { createStore, useStore } from "zustand";
+import { MessageType } from "./styles";
+
+type MessageWithId = {
+  id: number;
+  type?: MessageType;
+  title?: string;
+  detail?: string;
+  modal?: boolean; // by default assumed as false (modal dialog)
+  // only relevant for toast messages
+  delay?: number; // by default assumed as 5 seconds (0 = sticky)
+  // only relevant for modal messages
+  callback1?: () => void;
+  label1?: string;
+  callback2?: () => void;
+  label2?: string;
+};
+
+type Message = Omit<MessageWithId, "id">;
+
+export type MessageStore = {
+  messages: MessageWithId[];
+  // show message
+  showMessage: (message: Message) => void;
+  // dismiss message
+  dismissMessage: (id: number) => void;
+  // get first modal message
+  getModal: () => MessageWithId | undefined;
+  // get all toast messages
+  getToasts: () => MessageWithId[];
+};
+
+let currentId = 0;
+
+export const messageStore = createStore<MessageStore>((set, get) => ({
+  messages: [],
+  showMessage: (message) => {
+    if (
+      message.modal !== false &&
+      (message.callback1 ||
+        message.callback2 ||
+        message.label1 ||
+        message.label2)
+    ) {
+      message.modal = true;
+    }
+    const lastMessage = get().messages.at(-1);
+    if (
+      lastMessage &&
+      lastMessage.modal === message.modal &&
+      lastMessage.title === message.title &&
+      lastMessage.detail === message.detail
+    ) {
+      return; // do not show duplicate messages
+    }
+    set((state) => ({
+      messages: [...state.messages, { id: ++currentId, ...message }],
+    }));
+  },
+  dismissMessage: (id) => {
+    set((state) => ({
+      messages: state.messages.filter((message) => message.id !== id),
+    }));
+  },
+  getModal: () => {
+    return get().messages.find((message) => message.modal);
+  },
+  getToasts: () => {
+    return get().messages.filter((message) => !message.modal);
+  },
+}));
+
+// for usage in components
+export const useMessages = () => useStore(messageStore);
+
+// for usage outside components
+export const showMessage = (message: Message) => {
+  messageStore.getState().showMessage(message);
+};

--- a/src/components/register/register.tsx
+++ b/src/components/register/register.tsx
@@ -11,6 +11,7 @@ import {
   faArrowRightFromBracket,
   faPenToSquare,
 } from "@fortawesome/free-solid-svg-icons";
+import { useMessages } from "../messages/usage";
 
 const USERS_URL = process.env.REACT_APP_SVC_USERS_URL;
 
@@ -23,6 +24,7 @@ const Register = () => {
   const [accepted, setAccepted] = useState<boolean>(false);
   const [blocked, setBlocked] = useState<boolean>(true);
   const blocker = useBlocker(blocked);
+  const { showMessage } = useMessages();
 
   const back = () => {
     const lastUrl = sessionStorage.getItem("lastUrl");
@@ -80,11 +82,11 @@ const Register = () => {
     }
     const response = await fetchJson(url, method, userData).catch(() => null);
     if (response && response.status === ok) {
-      // TODO: should confirm that the user has been updated/registered
+      showMessage({ type: "success", title: "Registration successful" });
       navigate("/profile");
       return;
     }
-    alert("Could not register"); // TODO: nicer
+    showMessage({ type: "error", title: "Could not register" });
     back();
   };
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,9 +1,7 @@
 import { Log, User as OidcUser, UserManager } from "oidc-client-ts";
-import type {
-  OidcMetadata,
-  UserManagerSettings,
-} from "oidc-client-ts";
+import type { OidcMetadata, UserManagerSettings } from "oidc-client-ts";
 import { fetchJson } from "../utils/utils";
+import { showMessage } from "../components/messages/usage";
 
 /**
  * Interface for a full high-level user object.
@@ -153,7 +151,9 @@ class AuthService {
       try {
         oidcUser = await this.getOidcUser();
       } catch (error) {
-        console.error("Cannot get user:", error);
+        const title = "Cannot get user";
+        showMessage({ type: "error", title });
+        console.error(title, error);
         oidcUser = null;
       }
     }
@@ -176,13 +176,19 @@ class AuthService {
               changed: name !== userData.name || email !== userData.email,
             };
           } else if (response.status !== 404) {
-            console.error("Cannot verify user:", response.statusText);
+            const title = "Cannot verify user";
+            showMessage({ type: "error", title });
+            console.error(title, response.statusText);
           }
         } catch (error) {
-          console.error("Cannot access the server:", error);
+          const title = "Cannot access the server";
+          showMessage({ type: "error", title });
+          console.error(title, error);
         }
       } else {
-        console.error("Cannot get required user properties.")
+        const title = "Cannot get required user properties";
+        showMessage({ type: "error", title });
+        console.error(title);
       }
     }
     this.setUser(user);


### PR DESCRIPTION
This PR adds support for system wide user messages.

- These messages can be used
  - inside components via `useMessages` hook
  - outside components via `showMessage` function
- The messages can be modal (dialogs) or toasts (non-modal), controlled via the property `modal`.
- Modal messages can have callbacks for primary and secondary actions.
- Non-modal messages can auto-hide after a certain time (default 5s, but can also be different or sticky).
- Only one modal message is displayed at a time, but multiple modal messages are displayed together (stacked).
- Duplicate messages are automatically ignored.
- The messages can have various flavors, controlled via the property `type`, which can be `error`, `warning`, `info`, or `success` (the default).
- Messages can have a short title and a longer detail text.

This PR also implements these messages where so far we have only used `console.error` and `alerts`.

Since the message can appear as system messages independently of components, a global state management mechanism needed to be introduced. I decided to use the *Zustand* library for this purpose, becausse it's simpler than *Redux* and even the now built-in `useReducer` and also supports access from outside components.