### PR TITLE
Local dev improvements (hexkit, switch http and https)

### DIFF
--- a/.devcontainer/.data_portal_ui.yaml
+++ b/.devcontainer/.data_portal_ui.yaml
@@ -1,5 +1,5 @@
 # config parameters for development
-host: localhost
+host: 127.0.0.1
 port: 8080
 svc_search_url: "http://127.0.0.1:8001"
 svc_repository_url: "http://127.0.0.1:8002"

--- a/.devcontainer/create_cert
+++ b/.devcontainer/create_cert
@@ -19,12 +19,13 @@ test ! -f "$CERTFILE" -o ! -f "$KEYFILE" && \
 
 # also add local environment that makes use of this
 
-test ! -f "$ENVFILE" && echo "\
+if ! test -f "$ENVFILE" || ! grep -q "HTTPS=" "$ENVFILE"; then
+echo "
 HTTPS=true
 SSL_CRT_FILE=.devcontainer/$CERTFILE
 SSL_KEY_FILE=.devcontainer/$KEYFILE
-DATA_PORTAL_UI_HOST=$HOST
-DATA_PORTAL_UI_PORT=443
 REACT_APP_CLIENT_URL=https://$HOST/
 REACT_APP_OIDC_CLIENT_ID=$CLIENT_ID # please adapt
-REACT_APP_BASIC_AUTH=$BASIC_AUTH # please adapt" > "$ENVFILE"
+REACT_APP_BASIC_AUTH=$BASIC_AUTH # please adapt
+" >> "$ENVFILE"
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,101 +1,94 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.178.0/containers/typescript-node
 {
-	"name": "Data Portal UI",
+  "name": "Data Portal UI",
 
-	"dockerComposeFile": [
-		// the main compose file containing all data portal services,
-		// this file is obtained from an external repository
-		// (https://github.com/ghga-de/dataportal-dev-service-compose),
-		// to update please run `./update_main_compose_yml.sh`:
-		"docker-compose.yml",
+  "dockerComposeFile": [
+    // the main compose file containing all data portal services,
+    // this file is obtained from an external repository
+    "docker-compose.yml",
 
-		// a compose file that overwrite the ui service for development:
-		"docker-compose.override.yml"
-	],
+    // a compose file that overwrite the ui service for development:
+    "docker-compose.override.yml"
+  ],
 
-	// The 'service' property is the name of the service for the container that VS Code should
-	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
-	"service": "data_portal_ui_svc",
+  // The 'service' property is the name of the service for the container that VS Code should
+  // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+  "service": "data_portal_ui_svc",
 
-	// The optional 'workspaceFolder' property is the path VS Code should open by default when
-	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/workspace",
+  // The optional 'workspaceFolder' property is the path VS Code should open by default when
+  // connected. This is typically a file mount in .devcontainer/docker-compose.yml
+  "workspaceFolder": "/workspace",
 
-	"customizations": {
+  "customizations": {
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "/bin/bash"
+          }
+        },
 
-		"vscode": {
+        "eslint.enable": true,
+        "prettier.enable": true,
 
-			// Set *default* container specific settings.json values on container create.
-			"settings": {
-				"terminal.integrated.profiles.linux": {
-					"bash": {
-						"path": "/bin/bash"
-					}
-				},
+        "python.pythonPath": "/usr/local/bin/python",
+        "python.languageServer": "Pylance",
+        "python.linting.enabled": true,
+        "python.linting.pylintEnabled": true,
+        "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+        "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+        "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+        "python.formatting.provider": "black",
+        "python.analysis.typeCheckingMode": "basic",
+        "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+        "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+        "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+        "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+        "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+        "python.testing.pytestPath": "/usr/local/py-utils/bin/pytest",
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestEnabled": true,
 
-				"eslint.enable": true,
-				"prettier.enable": true,
+        "editor.formatOnSave": true,
+        "editor.renderWhitespace": "all",
+        "editor.rulers": [88],
+        "licenser.license": "Custom",
+        "licenser.customHeaderFile": "/workspace/.devcontainer/license_header.txt"
+      },
 
-				"python.pythonPath": "/usr/local/bin/python",
-				"python.languageServer": "Pylance",
-				"python.linting.enabled": true,
-				"python.linting.pylintEnabled": true,
-				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-				"python.formatting.provider": "black",
-				"python.analysis.typeCheckingMode": "basic",
-				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
-				"python.testing.pytestPath": "/usr/local/py-utils/bin/pytest",
-				"python.testing.unittestEnabled": false,
-				"python.testing.pytestEnabled": true,
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "mikestead.dotenv",
+        "ms-azuretools.vscode-docker",
+        "dbaeumer.vscode-eslint",
+        "paulshen.paul-typescript-toolkit",
+        "esbenp.prettier-vscode",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "redhat.vscode-yaml",
+        "eamodio.gitlens",
+        "github.vscode-pull-request-github",
+        "streetsidesoftware.code-spell-checker",
+        "yzhang.markdown-all-in-one",
+        "visualstudioexptteam.vscodeintellicode",
+        "ymotongpoo.licenser",
+        "editorconfig.editorconfig"
+      ]
+    }
+  },
 
-				"editor.formatOnSave": true,
-				"editor.renderWhitespace": "all",
-				"editor.rulers": [
-					88
-				],
-				"licenser.license": "Custom",
-				"licenser.customHeaderFile": "/workspace/.devcontainer/license_header.txt"
-			},
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [443, 8000, 8001, 8002],
 
-			// Add the IDs of extensions you want installed when the container is created.
-			"extensions": [
-				"mikestead.dotenv",
-				"ms-azuretools.vscode-docker",
-				"dbaeumer.vscode-eslint",
-				"paulshen.paul-typescript-toolkit",
-				"esbenp.prettier-vscode",
-				"ms-python.python",
-				"ms-python.vscode-pylance",
-				"redhat.vscode-yaml",
-				"eamodio.gitlens",
-				"github.vscode-pull-request-github",
-				"streetsidesoftware.code-spell-checker",
-				"yzhang.markdown-all-in-one",
-				"visualstudioexptteam.vscodeintellicode",
-				"ymotongpoo.licenser",
-				"editorconfig.editorconfig"
-			]
-		}
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "dev_install",
 
-	},
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node",
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "dev_install",
-
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node",
-
-	"features": {
-		"python": "3.10"
-	}
+  "features": {
+    "python": "3.10"
+  }
 }

--- a/.devcontainer/docker-compose.override.yml
+++ b/.devcontainer/docker-compose.override.yml
@@ -1,20 +1,19 @@
-version: '3.2'
+version: "3"
 services:
   data_portal_ui_svc:
-
     build:
       context: .
       dockerfile: ./Dockerfile
-
-    command: /bin/sh -c "while sleep 1000; do :; done"
 
     environment:
       DATA_PORTAL_UI_HOST: 0.0.0.0
       DATA_PORTAL_UI_PORT: 8080
 
     ports:
-      - 8000:8080
-      - 443:8080
+      - 127.0.0.1:8000:8080
+      - 127.0.0.1:443:8080
 
     volumes:
       - ..:/workspace:cached
+
+    command: sleep infinity

--- a/.devcontainer/docker-compose.override.yml
+++ b/.devcontainer/docker-compose.override.yml
@@ -5,15 +5,16 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    
+
     command: /bin/sh -c "while sleep 1000; do :; done"
 
     environment:
       DATA_PORTAL_UI_HOST: 0.0.0.0
-      DATA_PORTAL_UI_PORT: 443
+      DATA_PORTAL_UI_PORT: 8080
 
     ports:
-      - 443:443
+      - 8000:8080
+      - 443:8080
 
     volumes:
       - ..:/workspace:cached

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       DATA_PORTAL_UI_HOST: 0.0.0.0
       DATA_PORTAL_UI_PORT: 8080
     ports:
-      - 8000:8080
+      - 127.0.0.1:8000:8080
     depends_on:
       - metadata_search_svc
       - metadata_rep
@@ -41,7 +41,7 @@ services:
       metadata-search-service
       '''
     ports:
-      - 8001:8080
+      - 127.0.0.1:8001:8080
     depends_on:
       - metadata_db
 
@@ -50,13 +50,13 @@ services:
   metadata_pop:
     image: ghga/metadata-populate-job:main
     environment:
-       DATA_DB_NAME: metadata
-       DATA_DB_URL: mongodb://metadata_db:27017
-    entrypoint: [ "bash", "-c", "./clean-data.sh && ./populate-data.sh" ]
+      DATA_DB_NAME: metadata
+      DATA_DB_URL: mongodb://metadata_db:27017
+    entrypoint: ["bash", "-c", "./clean-data.sh && ./populate-data.sh"]
     env_file:
-     - local.env
+      - local.env
     depends_on:
-      - metadata_db  
+      - metadata_db
 
   #metadata repo
 
@@ -75,7 +75,7 @@ services:
 
     entrypoint: ["metadata-repository-service"]
     ports:
-      - 8002:8080
+      - 127.0.0.1:8002:8080
     depends_on:
       - metadata_db
 

--- a/configure_build_serve/requirements.txt
+++ b/configure_build_serve/requirements.txt
@@ -1,1 +1,1 @@
-ghga-service-chassis-lib==0.17.4
+hexkit==0.9.2

--- a/configure_build_serve/run.py
+++ b/configure_build_serve/run.py
@@ -15,7 +15,7 @@ import argparse
 import os
 from pathlib import Path
 from subprocess import Popen
-from ghga_service_chassis_lib.config import config_from_yaml
+from hexkit.config import config_from_yaml
 from pydantic import BaseSettings
 
 ROOT_DIR = Path(__file__).parent.parent.resolve()

--- a/src/components/login/profile.tsx
+++ b/src/components/login/profile.tsx
@@ -20,8 +20,8 @@ const Profile = () => {
     async function fetchData() {
       const user = await authService.getUser();
       setUser(user);
-      if (user) {
-        const url = `${WPS_URL}/datasets`;
+      if (user?.id) {
+        const url = `${WPS_URL}/users/${user.id}/datasets`;
         try {
           const response = await fetchJson(url);
           const datasets = await response.json();

--- a/src/components/workPackage/workPackage.tsx
+++ b/src/components/workPackage/workPackage.tsx
@@ -50,8 +50,8 @@ export function WorkPackage() {
       let datasets: Dataset[] | null = null;
       const user = await authService.getUser();
       setUser(user);
-      if (user) {
-        const url = `${WPS_URL}/datasets`;
+      if (user?.id) {
+        const url = `${WPS_URL}/users/${user.id}/datasets`;
         try {
           const response = await fetchJson(url);
           datasets = await response.json();

--- a/src/mocks/data.js
+++ b/src/mocks/data.js
@@ -52,7 +52,7 @@ export const data = {
   "GET /api/auth/users/*": user,
 
   // Datasets
-  "GET /api/wps/datasets": datasets,
+  "GET /api/wps/users/j.doe@ghga.de/datasets": datasets,
 
   // Work packages
   // example key for input: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI


### PR DESCRIPTION
This PR suggests two changes:
- Replace the obsolete GHGA chassis lib with hexkit
- Make it easier to switch between https and http by always running on the same port in the container

It accidentally also contains the changes from #128.