### PR TITLE
Use Zustand for authenticated user state (GSI-74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,28 @@
 # production
 /build
 
-# misc
-.DS_Store
+# environment files
 **/*.env
 
 # test certificate
 *.pem
 
+# Python artifacts
+*.py[cod]
+__pycache__/
+__pypackages__/
+
+# virtual environments
+.env/
+.venv/
+
+# VS Code settings
+.vscode/
+
 # log files
 npm-debug.log*
+
+# desktop settings and thumbnails
+.DS_Store
+desktop.ini
+thumbs.db

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ import Register from "./components/register/register";
 import Profile from "./components/login/profile";
 import { MessageContainer } from "./components/messages/container";
 import { useMessages } from "./components/messages/usage";
-import authService from "./services/auth";
+import { authService } from "./services/auth";
 import { useLayoutEffect } from "react";
 
 const router = createBrowserRouter(

--- a/src/components/header/loginButton.tsx
+++ b/src/components/header/loginButton.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { NavLink, useLocation } from "react-router-dom";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import {
   Button,
   Overlay,
@@ -8,32 +8,25 @@ import {
   Popover,
   Tooltip,
 } from "react-bootstrap";
-import authService, { User } from "../../services/auth";
 import lsLogin from "../../assets/loginLS/ls-login.png";
 import {
   faArrowRightFromBracket,
   faArrowRightToBracket,
   faPenToSquare,
 } from "@fortawesome/free-solid-svg-icons";
+import { useAuth } from "../../services/auth";
 
 const LoginButton = () => {
-  const [user, setUser] = useState<User | null>(null);
+  const { user, loginUser, logoutUser } = useAuth();
 
   let location = useLocation();
 
-  useEffect(() => {
-    authService.getUser().then(setUser);
-    document.addEventListener("auth", (e) =>
-      setUser((e as CustomEvent).detail)
-    );
-  }, []);
-
-  function onLogin() {
+  const login = async () => {
     // memorize the last URL when the login button was clicked
     if (location.pathname !== "/register")
       sessionStorage.setItem("lastUrl", window.location.href);
-    authService.login();
-  }
+    await loginUser();
+  };
 
   const [showTooltip, setShowTooltip] = useState(false);
   const target = useRef(null);
@@ -41,8 +34,7 @@ const LoginButton = () => {
   const [showPopover, setShowPopover] = useState(false);
 
   const logout = async () => {
-    await authService.logout();
-    setUser(null);
+    await logoutUser();
     window.location.reload();
   };
 
@@ -70,7 +62,10 @@ const LoginButton = () => {
                     <Button
                       variant="secondary"
                       className="text-white fs-7"
-                      onClick={() => {setShowPopover(false); document.body.click()}}
+                      onClick={() => {
+                        setShowPopover(false);
+                        document.body.click();
+                      }}
                     >
                       <FontAwesomeIcon icon={faPenToSquare} className="me-2" />
                       Complete registration
@@ -251,7 +246,7 @@ const LoginButton = () => {
                     Alternatively, you can also activate an LS account with
                     username and password.
                   </p>
-                  <button className="p-0 border-0" onClick={() => onLogin()}>
+                  <button className="p-0 border-0" onClick={() => login()}>
                     <img src={lsLogin} alt="LS Login" width="200px" />
                   </button>
                 </Popover.Body>

--- a/src/components/login/callback.tsx
+++ b/src/components/login/callback.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Col, Container, Row, Spinner } from "react-bootstrap";
-import authService from "../../services/auth";
+import { authService } from "../../services/auth";
 import { useMessages } from "../messages/usage";
 
 /** Handle redirect after OIDC login */

--- a/src/components/login/profile.tsx
+++ b/src/components/login/profile.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Alert, Button, Container, Row, Col } from "react-bootstrap";
 import { useNavigate, NavLink } from "react-router-dom";
 import { useMessages } from "../messages/usage";
-import authService, { fullName, User } from "../../services/auth";
+import { useAuth } from "../../services/auth";
 import { fetchJson } from "../../utils/utils";
 
 const WPS_URL = process.env.REACT_APP_SVC_WPS_URL;
@@ -12,14 +12,12 @@ const WPS_URL = process.env.REACT_APP_SVC_WPS_URL;
 const Profile = () => {
   const navigate = useNavigate();
 
-  const [user, setUser] = useState<User | null | undefined>(undefined);
   const [numDatasets, setNumDatasets] = useState<number>(0);
   const { showMessage } = useMessages();
+  const { user, logoutUser } = useAuth();
 
   useEffect(() => {
     async function fetchData() {
-      const user = await authService.getUser();
-      setUser(user);
       if (user?.id) {
         const url = `${WPS_URL}/users/${user.id}/datasets`;
         try {
@@ -36,12 +34,7 @@ const Profile = () => {
       }
     }
     fetchData();
-  }, [showMessage]);
-
-  const logout = async () => {
-    await authService.logout();
-    setUser(null);
-  };
+  }, [showMessage, user]);
 
   const back = () => {
     const lastUrl = sessionStorage.getItem("lastUrl");
@@ -58,7 +51,7 @@ const Profile = () => {
   } else
     content = (
       <div>
-        <h1 style={{ margin: "1em 0" }}>Welcome, {fullName(user)}!</h1>
+        <h1 style={{ margin: "1em 0" }}>Welcome, {user.fullName}!</h1>
         <div style={{ margin: "1em 0" }}>
           <p>
             We will communicate with you via this email address: &nbsp;
@@ -94,7 +87,11 @@ const Profile = () => {
           )}
         </div>
         <div style={{ margin: "2em 0", textAlign: "right" }}>
-          <Button variant="secondary" className="text-white" onClick={logout}>
+          <Button
+            variant="secondary"
+            className="text-white"
+            onClick={logoutUser}
+          >
             Logout
           </Button>
         </div>

--- a/src/components/register/register.tsx
+++ b/src/components/register/register.tsx
@@ -1,8 +1,7 @@
-import { ChangeEvent, FormEvent, useEffect, useState } from "react";
+import { ChangeEvent, FormEvent, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { unstable_useBlocker as useBlocker } from "react-router-dom";
 import { Button, Container, Modal, Row, Col } from "react-bootstrap";
-import authService, { fullName, User } from "../../services/auth";
 import { fetchJson } from "../../utils/utils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -12,6 +11,7 @@ import {
   faPenToSquare,
 } from "@fortawesome/free-solid-svg-icons";
 import { useMessages } from "../messages/usage";
+import { useAuth } from "../../services/auth";
 
 const USERS_URL = process.env.REACT_APP_SVC_USERS_URL;
 
@@ -19,12 +19,12 @@ const USERS_URL = process.env.REACT_APP_SVC_USERS_URL;
 
 const Register = () => {
   const navigate = useNavigate();
-  const [user, setUser] = useState<User | null | undefined>(undefined);
   const [title, setTitle] = useState<string>("");
   const [accepted, setAccepted] = useState<boolean>(false);
   const [blocked, setBlocked] = useState<boolean>(true);
   const blocker = useBlocker(blocked);
   const { showMessage } = useMessages();
+  const { user, logoutUser } = useAuth();
 
   const back = () => {
     const lastUrl = sessionStorage.getItem("lastUrl");
@@ -41,7 +41,7 @@ const Register = () => {
   };
 
   const logout = async () => {
-    await authService.logout();
+    await logoutUser();
     unblock();
     back();
   };
@@ -90,11 +90,6 @@ const Register = () => {
     back();
   };
 
-  useEffect(() => {
-    if (authService.user) setUser(authService.user);
-    else authService.getUser().then(setUser);
-  }, [user]);
-
   const handleTitle = (event: ChangeEvent<HTMLSelectElement>) => {
     setTitle(event.target.value);
   };
@@ -120,7 +115,7 @@ const Register = () => {
           <FontAwesomeIcon icon={faIdCard} className="me-2 text-secondary" />{" "}
           Registration with GHGA
         </h1>
-        <h2 className="mt-4">Welcome, {fullName(user)}!</h2>
+        <h2 className="mt-4">Welcome, {user.fullName}!</h2>
         <p>{prompt()}</p>
         <form onSubmit={handleSubmit} className="mt-4">
           <div className="row g-3 mb-3">

--- a/src/components/workPackage/workPackage.tsx
+++ b/src/components/workPackage/workPackage.tsx
@@ -14,7 +14,7 @@ import {
   faUpload,
 } from "@fortawesome/free-solid-svg-icons";
 import { useMessages } from "../messages/usage";
-import authService, { User } from "../../services/auth";
+import { useAuth } from "../../services/auth";
 import { fetchJson } from "../../utils/utils";
 import { Buffer } from "buffer";
 
@@ -37,19 +37,17 @@ export function WorkPackage() {
   const [datasets, setDatasets] = useState<Dataset[] | null | undefined>(
     undefined
   );
-  const [user, setUser] = useState<User | null | undefined>(undefined);
   const [dataset, setDataset] = useState<Dataset | undefined>(undefined);
   const [files, setFiles] = useState<string | undefined>(undefined);
   const [userKey, setUserKey] = useState<string | undefined>(undefined);
   const [errors, setErrors] = useState<Errors>({});
   const [token, setToken] = useState<string | null | undefined>(undefined);
   const { showMessage } = useMessages();
+  const { user } = useAuth();
 
   useEffect(() => {
     async function fetchData() {
       let datasets: Dataset[] | null = null;
-      const user = await authService.getUser();
-      setUser(user);
       if (user?.id) {
         const url = `${WPS_URL}/users/${user.id}/datasets`;
         try {
@@ -66,7 +64,7 @@ export function WorkPackage() {
       setDatasets(datasets);
     }
     fetchData();
-  }, [showMessage]);
+  }, [showMessage, user]);
 
   if (datasets === undefined) {
     return (

--- a/src/mocks/data.js
+++ b/src/mocks/data.js
@@ -49,7 +49,7 @@ const workPackageToken = {
 
 export const data = {
   // User registry
-  "GET /api/auth/users/*": user,
+  [`GET /api/auth/users/${user.ext_id}`]: user,
 
   // Datasets
   "GET /api/wps/users/j.doe@ghga.de/datasets": datasets,

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -2,17 +2,17 @@ import { rest } from "msw";
 import { data } from "./data";
 import { setOidcUser } from "./login";
 
-const FAKE_AUTH = true;
-
 const CLIENT_URL = process.env["REACT_APP_CLIENT_URL"];
 const OIDC_AUTHORITY_URL = process.env["REACT_APP_OIDC_AUTHORITY_URL"];
 const OIDC_CONFIG_URL = OIDC_AUTHORITY_URL + ".well-known/openid-configuration";
+
+const fakeAuth = !!CLIENT_URL.match(/127\.|local/);
 
 // handlers for REST endpoints
 export const handlers = [
   // intercept OIDC configuration request and redirect to profile page
   rest.get(OIDC_CONFIG_URL, (req, res, ctx) => {
-    if (FAKE_AUTH) {
+    if (fakeAuth) {
       setOidcUser();
       return res(
         ctx.json({

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,28 @@
+// Note that this currently works only as a CommonJS module
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+const clientUrl = process.env.REACT_APP_CLIENT_URL;
+const basicAuth = process.env.REACT_APP_BASIC_AUTH || null;
+
+const logOptions = {
+  onProxyReq: (proxyReq, req, res) => {
+    console.log("\n", req.method, "request to", req.url);
+    console.log("with headers", JSON.stringify(proxyReq.getHeaders()));
+  },
+  onProxyRes: (proxyRes, req, res) => {
+    console.log("response status", proxyRes.statusCode, proxyRes.statusMessage);
+    console.log("with headers", JSON.stringify(proxyRes.headers));
+  },
+};
+
+const authServiceProxy = {
+  target: clientUrl,
+  changeOrigin: true,
+  secure: true,
+  auth: basicAuth,
+  ...logOptions,
+};
+
+module.exports = function (app) {
+  app.use("/api/auth", createProxyMiddleware(authServiceProxy));
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,7 +7,7 @@ import {
 } from "../models/dataset";
 import { facetFilterModel } from "../models/facets";
 import { querySearchService } from "../api/browse";
-import authService from "../services/auth";
+import { authService } from "../services/auth";
 
 const CLIENT_URL = process.env.REACT_APP_CLIENT_URL;
 
@@ -36,7 +36,7 @@ export const scrollUp = () => {
 };
 
 /**
- * Convert a string representation of filter into an array of objects 
+ * Convert a string representation of filter into an array of objects
  * that conform to the facetFilterModel.
  * @param filterString - Semicolon-separated string of key-value pairs
  * @returns facetFilterModelList
@@ -57,7 +57,7 @@ export const getFilterParams = (filterString: string | null) => {
 };
 
 /**
- * Convert byte size into a human-readable format 
+ * Convert byte size into a human-readable format
  * @param bytes - Bytes as number
  * @returns Human readable size string, e.g. 5 kB
  */
@@ -87,11 +87,11 @@ export const parseBytes = (bytes: number) => {
 /**
  * Handle filters and call querySearchService to get search results from API
  * and set the search results, applied filters and page states of a component
- * 
+ *
  * @remarks
- * If appliedFilterDict is specified (not null) these filters are used, 
+ * If appliedFilterDict is specified (not null) these filters are used,
  * otherwise filterDict is used and the appliedFilterDict is updated accordingly.
- * 
+ *
  * @param setSearchResults - SetState function that sets search results state conforms to the searchResponseModel or null
  * @param filterDict - Array of objects that conform to the facetFilterModel.
  * @param searchKeyword - String representing the search keyword.
@@ -223,8 +223,7 @@ export const fetchJson = async (
   if (CLIENT_URL) {
     headers["Origin"] = CLIENT_URL;
   }
-  const user = await authService.getOidcUser();
-  const token = user?.access_token;
+  const token = await authService.getAccessToken();
   if (token) {
     // the Authorization header is already used for Basic auth,
     // therefore we use the X-Authorization header for the OIDC token


### PR DESCRIPTION
This PR changes how user state (the authenticated user data) is stored and distributed to components. Instead of storing it directly in the auth service, and distributing it to components via a custom event, we now use the Zustand library for storing the state, providing a convenient `useAuth` hook that can be used in components.

Also, added back the proxy configuration and some changes to easier switch between testing with and without LS login, and improved the .gitignore file a little bit.