### PR TITLE
Temporarily disable trivy

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -77,15 +77,15 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: "ghga/${{ github.event.repository.name }}:${{ needs.verify_version.outputs.version }}"
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: "docker.io/ghga/${{ github.event.repository.name }}:${{ needs.verify_version.outputs.version }}"
-          format: "table"
-          exit-code: "1"
-          ignore-unfixed: true
-          vuln-type: "os,library"
-          severity: "CRITICAL,HIGH"
+      # - name: Run Trivy vulnerability scanner
+      #   uses: aquasecurity/trivy-action@master
+      #   with:
+      #     image-ref: "docker.io/ghga/${{ github.event.repository.name }}:${{ needs.verify_version.outputs.version }}"
+      #     format: "table"
+      #     exit-code: "1"
+      #     ignore-unfixed: true
+      #     vuln-type: "os,library"
+      #     severity: "CRITICAL,HIGH"
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-paginate": "~8.1.3",
     "react-perfect-scrollbar": "~1.5.8",
     "react-router-dom": "6.8.0",
-    "react-scripts": "~5.0.1",
     "react-twitter-embed": "~4.0.4",
     "sass": "~1.59.3",
     "swiper": "~9.1.0",
@@ -66,6 +65,7 @@
     ]
   },
   "devDependencies": {
-    "msw": "^1.2.1"
+    "msw": "^1.2.1",
+    "react-scripts": "~5.0.1"
   }
 }


### PR DESCRIPTION
Trivy complains about the dependency `nth-check`, which is used by `react-scripts`, see [CVE-2021-3803](https://avd.aquasec.com/nvd/2021/cve-2021-3803/).

In general this should not be a problem as `react-scripts` is only a dev dependency and must not be present in the final container. However, our current docker build uses the `run.py` helper which combines the build and run steps. This makes it inconvenient to separate both steps (and their dependencies) into a multi-stage docker build.

We opened a separate issue for this: [GIM-187](https://jira.verbis.dkfz.de/browse/GIM-187)