### PR TITLE
Assume download work type if not specified

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-portal-ui",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "data-portal-ui",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "~6.4.0",
         "@fortawesome/free-brands-svg-icons": "~6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-portal-ui",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "~6.4.0",

--- a/src/components/workPackage/workPackage.tsx
+++ b/src/components/workPackage/workPackage.tsx
@@ -51,6 +51,10 @@ export function WorkPackage() {
           console.log(error);
         }
       }
+      // assume work type "download" when not specified
+      datasets?.forEach(
+        (dataset) => (dataset.workType = dataset.workType || "download")
+      );
       setDatasets(datasets);
     }
     fetchData();
@@ -160,9 +164,7 @@ export function WorkPackage() {
 
   function handleSelect(id: string) {
     setDataset(
-      id && datasets
-        ? datasets.find((dataset) => dataset.id === id && dataset.workType)
-        : undefined
+      id && datasets ? datasets.find((dataset) => dataset.id === id) : undefined
     );
   }
 


### PR DESCRIPTION
Currently the UI expects a work type for datasets, but the WPS does not send one, although it probably should. This is just a quick remedy to make the UI a bit more relaxed so that it works in both cases.