### PR TITLE
Split files input properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-portal-ui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "data-portal-ui",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "~6.4.0",
         "@fortawesome/free-brands-svg-icons": "~6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-portal-ui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "~6.4.0",

--- a/src/components/workPackage/workPackage.tsx
+++ b/src/components/workPackage/workPackage.tsx
@@ -210,7 +210,7 @@ export function WorkPackage() {
     )
       return;
     const url = `${WPS_URL}/work-packages`;
-    const fileIds = (files || "").split(/[,\s]+/);
+    const fileIds = (files || "").split(/[,\s]+/).filter((file) => file);
     const data = {
       dataset_id: dataset.id,
       type: dataset.workType,


### PR DESCRIPTION
The split method in JavaScript also keeps empty strings at the beginning and the end, we need to filter them out.