### PR TITLE
Create a more compatible dev certificate

### DIFF
--- a/.devcontainer/create_cert
+++ b/.devcontainer/create_cert
@@ -11,11 +11,27 @@ BASIC_AUTH=username:password
 
 cd /workspace/.devcontainer
 
-test ! -f "$CERTFILE" -o ! -f "$KEYFILE" && \
-  openssl req -x509 -newkey rsa:4096 -days 356 \
-    -out "$CERTFILE" -keyout "$KEYFILE" \
-    -subj "/CN=$HOST" -nodes \
-    -addext "subjectAltName=DNS:$HOST,DNS:localhost"
+if ! test -f "$CERTFILE" || ! test -f "$KEYFILE"; then
+  echo "Creating self-signed certificate for $HOST"
+  openssl req -x509 -newkey rsa:4096 -nodes \
+    -out "ca-$CERTFILE" -keyout "ca-$KEYFILE" \
+    -subj "/CN=$HOST" -days 356
+  openssl req -newkey rsa:4096 -nodes \
+    -out "req-$CERTFILE" -keyout "$KEYFILE" \
+    -subj "/CN=$HOST"
+  echo "subjectAltName=DNS:$HOST,DNS:localhost
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth" > "ca.ext"
+  openssl x509 -req \
+    -CA "ca-$CERTFILE" -CAkey "ca-$KEYFILE" \
+    -in "req-$CERTFILE" -out "$CERTFILE" \
+    -CAcreateserial -days 356 \
+    -extfile ca.ext
+  rm -f "req-$CERTFILT" "ca-$KEYFILE" ca.ext "ca-*.srl"
+  echo "Add ca-$CERTFILE to your browser's trusted certificates"
+fi
 
 # also add local environment that makes use of this
 


### PR DESCRIPTION
There was a problem with the old simple way of creating a self-signed certificate, since Firefox only accepts the certificate if `CA:FALSE` is set for the basicConstraints extension. It does not accept a certificate that is both a CA and a server certificate.