### PR TITLE
Optional corner ribbon showing the version

### DIFF
--- a/configure_build_serve/run.py
+++ b/configure_build_serve/run.py
@@ -13,6 +13,7 @@ To get help run:
 
 import argparse
 import os
+import json
 from pathlib import Path
 from subprocess import Popen
 from hexkit.config import config_from_yaml
@@ -33,6 +34,7 @@ class Config(BaseSettings):
     host: str = "localhost"
     port: int = 8080
     client_url: str = "https://data.staging.ghga.dev/"
+    ribbon_text: str = "Development v$v"
     mass_url: str = "/api/mass"
     metldata_url: str = "/api/metldata"
     ars_url: str = "/api/ars"
@@ -62,6 +64,10 @@ def set_react_app_env_vars(config: Config):
     """
 
     simplelog("Setting env vars for use in React App:")
+    # pass the version as env var
+    package = json.load(open("../package.json"))
+    os.environ["REACT_APP_VERSION"] = package["version"]
+    # pass config params as env vars
     for name, value in config.model_dump().items():
         if name not in IGNORE_PARAMS_FOR_REACT_APP and value is not None:
             env_var_name = f"REACT_APP_{name.upper()}"

--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -23,7 +23,7 @@ div.version-ribbon {
   background-color: #b11;
   overflow: hidden;
   white-space: nowrap;
-  position: fixed;
+  position: absolute;
   height: 30px;
   width: 260px;
   left: -50px;

--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -18,3 +18,31 @@ $carousel-control-width: 3%;
     z-index: $zIndexContent;
   }
 }
+
+div.version-ribbon {
+  background-color: #b11;
+  overflow: hidden;
+  white-space: nowrap;
+  position: fixed;
+  height: 30px;
+  width: 260px;
+  left: -50px;
+  top: 65px;
+  transform: rotate(-45deg);
+  box-shadow: 0 0 10px #888;
+  z-index: 999;
+
+  span {
+    display: inline-block;
+    color: #fee;
+    font-weight: bold;
+    width: 200px;
+    margin: 1px 30px;
+    padding: 0;
+    vertical-align: middle;
+    text-align: center;
+    text-shadow: 0 0 5px #444;
+    text-size-adjust: none;
+    cursor: pointer;
+  }
+}

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
-import HeaderNavbar from './headerNavbar'
 import { Container } from 'react-bootstrap'
+
+import HeaderNavbar from './headerNavbar'
+import VersionRibbon from './versionRibbon';
 
 /** Main header container of the site. It includes navigations. */
 const Header = () => {
   return (
     <Container className='mw-100 mx-0 p-0'>
       <HeaderNavbar />
+      <VersionRibbon />
     </Container>
   )
 }

--- a/src/components/header/versionRibbon.tsx
+++ b/src/components/header/versionRibbon.tsx
@@ -1,0 +1,19 @@
+import { useState } from "react";
+
+const VERSION = process.env.REACT_APP_VERSION || '?';
+const TEXT = (process.env.REACT_APP_BANNER_TEXT || '').replace('$v', VERSION);
+
+/** Corner ribbon for showing staging and version info. */
+const VersionRibbon = () => {
+  const [show, setShow] = useState(!!TEXT);
+
+  const click = () => setShow(false);
+
+  return show ? (
+    <div className="version-ribbon" onClick={click}>
+      <span>{TEXT}</span>
+    </div>
+  ) : null;
+}
+
+export default VersionRibbon;

--- a/src/components/header/versionRibbon.tsx
+++ b/src/components/header/versionRibbon.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 const VERSION = process.env.REACT_APP_VERSION || '?';
-const TEXT = (process.env.REACT_APP_BANNER_TEXT || '').replace('$v', VERSION);
+const TEXT = (process.env.REACT_APP_RIBBON_TEXT || '').replace('$v', VERSION);
 
 /** Corner ribbon for showing staging and version info. */
 const VersionRibbon = () => {


### PR DESCRIPTION
This PR adds a prominent red ribbon on the top left corner to show that this ia a beta/development/staging version.

The text of the ribbon is configurable and can contain a placeholder for the version number and be also empty when no ribbon should be shown.

When clicking on the ribbon, it goes away.