### PR TITLE
Update CSRF retrieval and add exception for verify-totp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-portal-ui",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-portal-ui",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "~6.4.2",
         "@fortawesome/free-brands-svg-icons": "~6.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-portal-ui",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "~6.4.2",

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -235,6 +235,15 @@ class AuthService {
   }
 
   /**
+   * Return the current User session from the session storage.
+   */
+  getCurrentUser(): User | null {
+    const session = sessionStorage.getItem("user");
+    const user: User | null = this.parseUserFromSession(session);
+    return user;
+  }
+
+  /**
    * Return the deserialized user session from a JSON-formatted string.
    */
   parseUserFromSession(session: string | null): User | null {
@@ -255,13 +264,6 @@ class AuthService {
     return user;
   }
 
-  /**
-   * Return the CSRF token from the user session.
-   */
-  async getCsrfToken(): Promise<string | undefined> {
-    const user = JSON.parse(sessionStorage.getItem("user") || '{}');
-    return user?.csrf;
-  }
 
 }
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -254,6 +254,15 @@ class AuthService {
     }
     return user;
   }
+
+  /**
+   * Return the CSRF token from the user session.
+   */
+  async getCsrfToken(): Promise<string | undefined> {
+    const user = JSON.parse(sessionStorage.getItem("user") || '{}');
+    return user?.csrf;
+  }
+
 }
 
 export const authService = new AuthService();

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -101,8 +101,10 @@ export const fetchJson = async (
   if (CLIENT_URL) {
     headers["Origin"] = CLIENT_URL.hostname;
   }
+  const urlObject = typeof url === 'string' ? new URL(url) : url;
   if (method.match(/^POST|PUT|PATCH|DELETE$/) &&
-      !additionalHeaders?.hasOwnProperty("X-Authorization")) {
+      (!additionalHeaders?.hasOwnProperty("X-Authorization") || 
+      (urlObject)?.pathname.includes("verify-totp"))) {
     const csrf = await authService.getCsrfToken();
     if (csrf) {
       headers["X-CSRF-Token"] = csrf;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -103,8 +103,7 @@ export const fetchJson = async (
   }
   if (method.match(/^POST|PUT|PATCH|DELETE$/) &&
       !additionalHeaders?.hasOwnProperty("X-Authorization")) {
-    const user = await authService.getUser();
-    const csrf = user?.csrf;
+    const csrf = await authService.getCsrfToken();
     if (csrf) {
       headers["X-CSRF-Token"] = csrf;
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -101,11 +101,9 @@ export const fetchJson = async (
   if (CLIENT_URL) {
     headers["Origin"] = CLIENT_URL.hostname;
   }
-  const urlObject = typeof url === 'string' ? new URL(url) : url;
-  if (method.match(/^POST|PUT|PATCH|DELETE$/) &&
-      (!additionalHeaders?.hasOwnProperty("X-Authorization") || 
-      (urlObject)?.pathname.includes("verify-totp"))) {
-    const csrf = await authService.getCsrfToken();
+  if (method.match(/^POST|PUT|PATCH|DELETE$/)) {
+    const user = authService.getCurrentUser();
+    const csrf = user?.csrf;
     if (csrf) {
       headers["X-CSRF-Token"] = csrf;
     }


### PR DESCRIPTION
This PR suggests fixes for two issues.

1- The `X-Authorization` is used to pass TOTP token, so **verify-totp** endpoint requires both `X-Authorization` and `X-CSRF-Token`, so an exception to cover this is added. https://github.com/ghga-de/data-portal-ui/pull/196/commits/eabcb588e9ed58f55dcaf887302744ce0ba1a273

2- The line `authService.getUser()` in `fetchJson` creates a recursive call loop between `getUser` and `fetchJson` methods which causes `RangeError: Maximum call stack size exceeded` error. https://github.com/ghga-de/data-portal-ui/pull/196/commits/c73450cffd1ab86c3f91cada4330d1f5e4f6c34e

The original error for the latter.
```
RangeError: Maximum call stack size exceeded
    at up (utils.ts:95:32)
    at Object.getUser (auth.ts:224:30)
    at up (utils.ts:106:36)
    at Object.getUser (auth.ts:224:30)
    at up (utils.ts:106:36)
    at Object.getUser (auth.ts:224:30)
    at up (utils.ts:106:36)
    at Object.getUser (auth.ts:224:30)
    at up (utils.ts:106:36)
    at Object.getUser (auth.ts:224:30)
```