### PR TITLE
Use internal ID for IVA requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-portal-ui",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-portal-ui",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "~6.4.2",
         "@fortawesome/free-brands-svg-icons": "~6.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-portal-ui",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "~6.4.2",

--- a/src/components/accessRequests/accessRequestsList/accessRequestsList.tsx
+++ b/src/components/accessRequests/accessRequestsList/accessRequestsList.tsx
@@ -117,7 +117,7 @@ const AccessRequestsList = (props: AccessRequestListProps) => {
   };
   const handleShowModal = async (accessRequest: AccessRequest) => {
     setSelectedAccessRequest(accessRequest);
-    const ivas = await getUserIVAs(props.user.ext_id);
+    const ivas = await getUserIVAs(props.user?.id);
     if (ivas) {
       setUserIVAs(ivas);
       setShowModal(true);

--- a/src/components/profile/newIVAsModal/newIVAModal.tsx
+++ b/src/components/profile/newIVAsModal/newIVAModal.tsx
@@ -8,7 +8,7 @@ import { IVA, IVAStatus, IVAType } from "../../../models/ivas";
 interface NewIVAModalProps {
   show: boolean;
   setShow: any;
-  userId: string | undefined;
+  userId: string;
   newUserIVA: any;
 }
 

--- a/src/components/profile/newIVAsModal/newIVAModal.tsx
+++ b/src/components/profile/newIVAsModal/newIVAModal.tsx
@@ -8,7 +8,7 @@ import { IVA, IVAStatus, IVAType } from "../../../models/ivas";
 interface NewIVAModalProps {
   show: boolean;
   setShow: any;
-  userId: string;
+  userId: string | undefined;
   newUserIVA: any;
 }
 

--- a/src/components/profile/profile.tsx
+++ b/src/components/profile/profile.tsx
@@ -116,7 +116,12 @@ const Profile = () => {
 
   const deleteUserIVA = async () => {
     let url = AUTH_URL;
-    url = new URL(`users/${user?.id}/ivas/${toDeleteIVA!.id}`, url);
+    const userId = user?.id;
+    const ivaId = toDeleteIVA?.id;
+    if (!userId || !ivaId) {
+      return;
+    }
+    url = new URL(`users/${userId}/ivas/${ivaId}`, url);
     let method: string = "DELETE",
       ok: number = 204;
     const response = await fetchJson(url, method).catch(() => null);
@@ -125,7 +130,7 @@ const Profile = () => {
         type: "success",
         title: "Contact address deleted successfully!",
       });
-      setUserIVAs(userIVAs.filter((x) => x.id !== toDeleteIVA!.id));
+      setUserIVAs(userIVAs.filter((x) => x.id !== ivaId));
       setToDeleteIVA(null);
       setShowDeletionConfirmationModal(false);
     } else {
@@ -237,7 +242,7 @@ const Profile = () => {
 
   let content;
   if (user === undefined) content = "Loading user data...";
-  else if (user === null) {
+  else if (!user?.id) {
     content = "Not logged in!";
     back();
   } else

--- a/src/components/profile/profile.tsx
+++ b/src/components/profile/profile.tsx
@@ -116,7 +116,7 @@ const Profile = () => {
 
   const deleteUserIVA = async () => {
     let url = AUTH_URL;
-    url = new URL(`users/${user?.ext_id}/ivas/${toDeleteIVA!.id}`, url);
+    url = new URL(`users/${user?.id}/ivas/${toDeleteIVA!.id}`, url);
     let method: string = "DELETE",
       ok: number = 204;
     const response = await fetchJson(url, method).catch(() => null);
@@ -190,7 +190,7 @@ const Profile = () => {
         }
 
         try {
-          const ivas = await getUserIVAs(user.ext_id);
+          const ivas = await getUserIVAs(user.id);
           if (ivas) {
             setUserIVAs(ivas);
           }
@@ -489,7 +489,7 @@ const Profile = () => {
         <NewIVAModal
           show={showNewIVAModal}
           setShow={setShowNewIVAModal}
-          userId={user.ext_id}
+          userId={user.id}
           newUserIVA={newUserIVA}
         />
         <DeletionConfirmationModal />

--- a/src/services/ivas.ts
+++ b/src/services/ivas.ts
@@ -19,6 +19,9 @@ import { showMessage } from "../components/messages/usage";
 
 // Get IVAs of a given user
 export async function getUserIVAs(userId: string | undefined): Promise<IVA[] | null> {
+  if (!userId) {
+    return null;
+  }
   const url = new URL(`users/${userId}/ivas`, AUTH_URL);
   try {
     const response = await fetchJson(url)

--- a/src/services/ivas.ts
+++ b/src/services/ivas.ts
@@ -18,7 +18,7 @@ import { IVA, UserWithIVA } from "../models/ivas";
 import { showMessage } from "../components/messages/usage";
 
 // Get IVAs of a given user
-export async function getUserIVAs(userId: string): Promise<IVA[] | null> {
+export async function getUserIVAs(userId: string | undefined): Promise<IVA[] | null> {
   const url = new URL(`users/${userId}/ivas`, AUTH_URL);
   try {
     const response = await fetchJson(url)


### PR DESCRIPTION
This PR replaces the external ID used for IVA requests with the internal ID. 

**Original problem:**
All the IVA API requests are using external ID, and get 403.
```
https://data.staging.ghga.dev/api/auth/users/6f16***@lifescience-ri.eu/ivas
> 403: {"detail":"Not authorized to create this IVA."}
```