### PR TITLE
Get IVAs of corresponding user in access manager

### DIFF
--- a/src/components/accessRequests/accessRequestsList/accessRequestsList.tsx
+++ b/src/components/accessRequests/accessRequestsList/accessRequestsList.tsx
@@ -117,7 +117,7 @@ const AccessRequestsList = (props: AccessRequestListProps) => {
   };
   const handleShowModal = async (accessRequest: AccessRequest) => {
     setSelectedAccessRequest(accessRequest);
-    const ivas = await getUserIVAs(props.user?.id);
+    const ivas = await getUserIVAs(accessRequest.user_id);
     if (ivas) {
       setUserIVAs(ivas);
       setShowModal(true);


### PR DESCRIPTION
The list of IVAs that the data steward can select from in the access request manager was populated with the IVAs from the data steward, not the respective user.