### PR TITLE
Fix some edge cases in the authentication flow (GSI-832)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,8 +96,6 @@ function Layout() {
           /Registered|(Needs|Lost|New)TotpToken/.test(user.state) &&
           !/^\/(setup|confirm)-2fa/.test(location.pathname)
         ) {
-          // user is new (needs to register)
-          // or her data changed (needs to confirm)
           navigate("/setup-2fa");
         }
         if (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,9 @@ function Layout() {
               callback1: () => {},
               label1: "Continue unauthenticated",
               callback2: () => {
-                if (!location.pathname.match("/(register|confirm-2fa|setup-2fa)")) {
+                if (
+                  !location.pathname.match("/(register|confirm-2fa|setup-2fa)")
+                ) {
                   sessionStorage.setItem("lastPath", location.pathname);
                 }
                 authService.login();

--- a/src/components/accessRequests/accessRequestsList/accessRequestModal.tsx
+++ b/src/components/accessRequests/accessRequestsList/accessRequestModal.tsx
@@ -15,7 +15,7 @@
 
 import { Button, Col, Modal, Row } from "react-bootstrap";
 import { ARS_URL, fetchJson } from "../../../utils/utils";
-import { showMessage } from "../../messages/usage";
+import { useMessages } from "../../messages/usage";
 import { AccessRequest } from "../../../models/submissionsAndRequests";
 import { useState } from "react";
 import {
@@ -44,6 +44,7 @@ const ROW_CLASSES = "mb-3";
 const AccessRequestModal = (props: AccessRequestModalProps) => {
   const [disabledButtons, setDisabledButtons] = useState(false);
   const [selectedIVA, setSelectedIVA] = useState("");
+  const { showMessage } = useMessages();
 
   async function handleButtonClickAccess(status: "allowed" | "denied") {
     if (props.accessRequest === undefined || props.userId === undefined) {

--- a/src/components/confirm2FA/confirm2FA.tsx
+++ b/src/components/confirm2FA/confirm2FA.tsx
@@ -31,7 +31,7 @@ import {
 import { useBlocker, useNavigate } from "react-router-dom";
 import { authService, useAuth } from "../../services/auth";
 import { AUTH_URL, fetchJson } from "../../utils/utils";
-import { showMessage } from "../messages/usage";
+import { useMessages } from "../messages/usage";
 
 const Confirm2FA = () => {
   const navigate = useNavigate();
@@ -45,8 +45,16 @@ const Confirm2FA = () => {
 
   const { user, logoutUser } = useAuth();
 
+  const { showMessage } = useMessages();
+
   const back = () => {
-    setTimeout(() => navigate(sessionStorage.getItem("lastPath") || "/"));
+    let path = sessionStorage.getItem("lastPath");
+    if (path) {
+      sessionStorage.removeItem("lastPath");
+    } else {
+      path = "/";
+    }
+    setTimeout(() => navigate(path!));
   };
 
   const stay = () => {
@@ -93,8 +101,8 @@ const Confirm2FA = () => {
   let content;
   if (user === undefined) {
     content = "Loading user data...";
-  } else if (user === null) {
-    // user is not logged in
+  } else if (!user || user.state !== "HasTotpToken") {
+    console.warn("Unexpected state:", user?.state);
     unblock();
     back();
   } else {

--- a/src/components/confirm2FA/confirm2FA.tsx
+++ b/src/components/confirm2FA/confirm2FA.tsx
@@ -94,6 +94,8 @@ const Confirm2FA = () => {
   if (user === undefined) {
     content = "Loading user data...";
   } else if (user === null) {
+    // user is not logged in
+    unblock();
     back();
   } else {
     const Lost2FAModal = (props: any) => {

--- a/src/components/ivaManager/ivaManagerList/ivaManagerListConfirmInvalidateModal.tsx
+++ b/src/components/ivaManager/ivaManagerList/ivaManagerListConfirmInvalidateModal.tsx
@@ -2,7 +2,7 @@ import { Button, Modal } from "react-bootstrap";
 import { UserWithIVA, IVAState, IVATypePrintable } from "../../../models/ivas";
 import { useState } from "react";
 import { AUTH_URL, fetchJson } from "../../../utils/utils";
-import { showMessage } from "../../messages/usage";
+import { useMessages } from "../../messages/usage";
 
 interface IvaManagerListConfirmInvalidateModalProps {
   show: boolean;
@@ -16,6 +16,7 @@ const IvaManagerListConfirmInvalidateModal = (
   props: IvaManagerListConfirmInvalidateModalProps
 ) => {
   const [disabledButtons, setDisabledButtons] = useState(false);
+  const { showMessage } = useMessages();
 
   async function handleInvalidate() {
     if (props.selectedIVA !== undefined) {

--- a/src/components/ivaManager/ivaManagerList/ivaManagerListConfirmTransmissionModal.tsx
+++ b/src/components/ivaManager/ivaManagerList/ivaManagerListConfirmTransmissionModal.tsx
@@ -2,7 +2,7 @@ import { Button, Modal } from "react-bootstrap";
 import { UserWithIVA, IVAState, IVATypePrintable } from "../../../models/ivas";
 import { useState } from "react";
 import { AUTH_URL, fetchJson } from "../../../utils/utils";
-import { showMessage } from "../../messages/usage";
+import { useMessages } from "../../messages/usage";
 
 interface IvaManagerListConfirmTransmissionModalProps {
   show: boolean;
@@ -17,6 +17,7 @@ const IvaManagerListConfirmTransmissionModal = (
   props: IvaManagerListConfirmTransmissionModalProps
 ) => {
   const [disabledButtons, setDisabledButtons] = useState(false);
+  const { showMessage } = useMessages();
 
   async function handleTransmitted() {
     if (props.selectedIVA !== undefined) {

--- a/src/components/ivaManager/ivaManagerList/ivaManagerListCreateCodeModal.tsx
+++ b/src/components/ivaManager/ivaManagerList/ivaManagerListCreateCodeModal.tsx
@@ -15,7 +15,7 @@
 
 import { Button, Form, Modal, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { AUTH_URL, fetchJson } from "../../../utils/utils";
-import { showMessage } from "../../messages/usage";
+import { useMessages } from "../../messages/usage";
 import { useEffect, useState } from "react";
 import { UserWithIVA, IVAState, IVATypePrintable } from "../../../models/ivas";
 
@@ -36,6 +36,8 @@ const IvaManagerListCreateCodeModal = (
   const [code, setCode] = useState("");
 
   const { selectedIVA, show, onUpdate } = props;
+
+  const { showMessage } = useMessages();
 
   useEffect(() => {
     async function fetchData() {
@@ -60,7 +62,9 @@ const IvaManagerListCreateCodeModal = (
             onUpdate();
             setDisabledButtons(false);
           } else {
-            throw new Error("Verification code could not be created: " + response.text);
+            throw new Error(
+              "Verification code could not be created: " + response.text
+            );
           }
         } catch (error) {
           console.error(error);

--- a/src/components/profile/callback.tsx
+++ b/src/components/profile/callback.tsx
@@ -22,7 +22,13 @@ const Callback = () => {
 
     const handleError = () => {
       showMessage({ type: "error", title: "Could not log in" });
-      navigate(sessionStorage.getItem("lastPath") || "/");
+      let path = sessionStorage.getItem("lastPath");
+      if (path) {
+        sessionStorage.removeItem("lastPath");
+      } else {
+        path = "/";
+      }
+      setTimeout(() => navigate(path!));
     };
 
     // in case the user tries to access without a state

--- a/src/components/profile/profile.tsx
+++ b/src/components/profile/profile.tsx
@@ -244,13 +244,14 @@ const Profile = () => {
   if (user === undefined) content = "Loading user data...";
   else if (!user?.id || user.state !== "Authenticated") {
     content = "Not logged in!";
+    if (sessionStorage.getItem("lastPath") === "/profile") {
+      sessionStorage.removeItem("lastPath");
+    }
     back();
   } else
     content = (
       <div>
-        <h3 style={{ margin: "1em 0" }}>
-          Welcome, {user.full_name}!
-        </h3>
+        <h3 style={{ margin: "1em 0" }}>Welcome, {user.full_name}!</h3>
         <div style={{ margin: "1em 0" }}>
           <Alert variant={user?.timeout ? "success" : "danger"}>
             {user.timeout

--- a/src/components/profile/profile.tsx
+++ b/src/components/profile/profile.tsx
@@ -237,7 +237,13 @@ const Profile = () => {
   }, [showMessage, user]);
 
   const back = () => {
-    setTimeout(() => navigate(sessionStorage.getItem("lastPath") || "/"));
+    let path = sessionStorage.getItem("lastPath");
+    if (path) {
+      sessionStorage.removeItem("lastPath");
+    } else {
+      path = "/";
+    }
+    setTimeout(() => navigate(path!));
   };
 
   let content;

--- a/src/components/profile/verificationModals/confirmVerificationModal.tsx
+++ b/src/components/profile/verificationModals/confirmVerificationModal.tsx
@@ -2,7 +2,7 @@ import { Button, Form, Modal } from "react-bootstrap";
 import { IVA, IVAState } from "../../../models/ivas";
 import { useState } from "react";
 import { AUTH_URL, fetchJson } from "../../../utils/utils";
-import { showMessage } from "../../messages/usage";
+import { useMessages } from "../../messages/usage";
 
 interface ConfirmVerificationModalProps {
   show: boolean;
@@ -12,6 +12,10 @@ interface ConfirmVerificationModalProps {
 }
 
 const ConfirmVerificationModal = (props: ConfirmVerificationModalProps) => {
+  const [disabledButton, setDisabledButton] = useState(true);
+  const [inputtedCode, setInputtedCode] = useState("");
+  const { showMessage } = useMessages();
+
   const HandleSubmit = async (verificationCode: string) => {
     setDisabledButton(true);
     let url = AUTH_URL;
@@ -43,9 +47,6 @@ const ConfirmVerificationModal = (props: ConfirmVerificationModalProps) => {
       setTimeout(() => setDisabledButton(false), 2000);
     }
   };
-
-  const [disabledButton, setDisabledButton] = useState(true);
-  const [inputtedCode, setInputtedCode] = useState("");
 
   return (
     <>

--- a/src/components/register/register.tsx
+++ b/src/components/register/register.tsx
@@ -48,10 +48,10 @@ const Register = () => {
   const prompt = () =>
     user?.id
       ? (user.state === "NeedsReRegistration"
-        ? "Your contact information has changed since you last registered. "
-        : "") + "Please confirm that the information given below is correct."
+          ? "Your contact information has changed since you last registered. "
+          : "") + "Please confirm that the information given below is correct."
       : "Since you haven't used our data portal before, " +
-      "we ask you to confirm your user data and register with us.";
+        "we ask you to confirm your user data and register with us.";
 
   const buttonText = () => (user?.id ? "Confirm" : "Register");
 
@@ -83,9 +83,9 @@ const Register = () => {
       // We need to check that and give a hint to the backend to reload the session.
       for (let attempt = 0; attempt < 5; attempt++) {
         const wait = (1 << attempt) * 50;
-        await new Promise(r => setTimeout(r, wait));
+        await new Promise((r) => setTimeout(r, wait));
         const user = await authService.getUser(true);
-        if (user?.id && user.state === 'Registered') {
+        if (user?.id && user.state === "Registered") {
           registered = true;
           break;
         }

--- a/src/components/register/setup2FA/setup2FA.tsx
+++ b/src/components/register/setup2FA/setup2FA.tsx
@@ -103,7 +103,9 @@ const Setup2FA = () => {
 
   let content;
   if (user === null) {
-    back(); // not authenticated
+    // user is not logged in
+    unblock();
+    back();
   } else if (!(user && twoFAURI)) {
     content = "Loading user data...";
   } else {

--- a/src/components/register/setup2FA/setup2FA.tsx
+++ b/src/components/register/setup2FA/setup2FA.tsx
@@ -32,7 +32,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { authService, useAuth } from "../../../services/auth";
 import { AUTH_URL, fetchJson } from "../../../utils/utils";
-import { showMessage } from "../../messages/usage";
+import { useMessages } from "../../messages/usage";
 
 const Setup2FA = () => {
   useEffect(() => {});
@@ -50,8 +50,16 @@ const Setup2FA = () => {
 
   const { user, logoutUser } = useAuth();
 
+  const { showMessage } = useMessages();
+
   const back = () => {
-    setTimeout(() => navigate(sessionStorage.getItem("lastPath") || "/"));
+    let path = sessionStorage.getItem("lastPath");
+    if (path) {
+      sessionStorage.removeItem("lastPath");
+    } else {
+      path = "/";
+    }
+    setTimeout(() => navigate(path!));
   };
 
   const stay = () => {
@@ -72,42 +80,44 @@ const Setup2FA = () => {
   };
 
   const getTOTPCode = async () => {
-    if (user && TOTPRequests === 0) {
-      setTOTPRequests(TOTPRequests + 1);
-      const url = new URL("totp-token", AUTH_URL);
-      if (user.state === "LostTotpToken") {
-        url.search = "?force=true";
+    if (!user || TOTPRequests) return;
+    setTOTPRequests(TOTPRequests + 1);
+    const url = new URL("totp-token", AUTH_URL);
+    if (user.state === "LostTotpToken") {
+      url.search = "?force=true";
+    }
+    try {
+      const response = await fetchJson(url, "POST");
+      if (response?.status !== 201) {
+        throw Error(response.statusText);
       }
-      try {
-        const response = await fetchJson(url, "POST");
-        if (response?.status !== 201) {
-          throw Error(response.statusText);
-        }
-        const { uri: token } = await response.json();
-        if (token) {
-          setTwoFAURI(token);
-        }
-      } catch (error) {
-        console.error("Cannot get TOTP code:", error);
-        showMessage({
-          type: "error",
-          title: "Cannot get 2FA code. Please try again later.",
-        });
+      const { uri: token } = await response.json();
+      if (token) {
+        setTwoFAURI(token);
       }
+    } catch (error) {
+      console.error("Cannot get TOTP code:", error);
+      showMessage({
+        type: "error",
+        title: "Cannot get 2FA code. Please try again later.",
+      });
     }
   };
 
-  if (TOTPRequests === 0) {
-    getTOTPCode();
-  }
-
   let content;
-  if (user === null) {
-    // user is not logged in
+  if (user === undefined) {
+    content = "Loading user data...";
+  } else if (
+    !user ||
+    !/Registered|(Needs|Lost|New)TotpToken/.test(user.state)
+  ) {
     unblock();
     back();
-  } else if (!(user && twoFAURI)) {
-    content = "Loading user data...";
+  } else if (!twoFAURI) {
+    if (!TOTPRequests) {
+      getTOTPCode();
+    }
+    content = "Creating second factor...";
   } else {
     content = (
       <>

--- a/src/utils/dataRequestFormModal.tsx
+++ b/src/utils/dataRequestFormModal.tsx
@@ -5,7 +5,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Modal, Row, Col, Button, Form } from "react-bootstrap";
-import { showMessage } from "../components/messages/usage";
+import { useMessages } from "../components/messages/usage";
 import { ARS_URL, fetchJson } from "./utils";
 import { useAuth } from "../services/auth";
 import { FormEvent, useState } from "react";
@@ -19,6 +19,8 @@ interface DataRequestFormModalProps {
 
 /** Modal that guides the user on how to access the dataset of interest. */
 const DataRequestFormModal = (props: DataRequestFormModalProps) => {
+  const { showMessage } = useMessages();
+
   const cleanEmail = (email: string) => {
     let clean_email: string = email;
     clean_email = clean_email.replace("[at]", "@");

--- a/src/utils/requestAccessButton.tsx
+++ b/src/utils/requestAccessButton.tsx
@@ -21,7 +21,7 @@ import { useAuth } from "../services/auth";
 import { AccessRequest } from "../models/submissionsAndRequests";
 import { useEffect, useState } from "react";
 import { ARS_URL, fetchJson } from "./utils";
-import { showMessage } from "../components/messages/usage";
+import { useMessages } from "../components/messages/usage";
 import { useNavigate } from "react-router-dom";
 
 interface RequestAccessButtonProps {
@@ -43,6 +43,8 @@ const RequestAccessButton = (props: RequestAccessButtonProps) => {
   >(undefined);
 
   const navigate = useNavigate();
+
+  const { showMessage } = useMessages();
 
   useEffect(() => {
     async function fetchData() {
@@ -91,7 +93,7 @@ const RequestAccessButton = (props: RequestAccessButtonProps) => {
       }
     }
     if (requests === null || requests === undefined) fetchData();
-  }, [props.accession, requests, user]);
+  }, [props.accession, requests, user, showMessage]);
 
   return (
     <Button


### PR DESCRIPTION
This PR fixes some edge cases in the user flow from login to full authentication.

Particularly, gracefully redirects back or to home page when the user got lost and one of the steps is called with the wrong state. Before, this would produce strange errors or empty pages.

Another edge cases is that the user dismisses the modal on the registration page by closing it (e.g. clicking outside) instead of clicking on "Continue".

Also, use the react hook for showing messages wherever possible.