### PR TITLE
Aggregate stats for all file types (GSI-833)

### DIFF
--- a/src/components/browse/dataset/datasetAccordion/datasetSummary/datasetFiles.tsx
+++ b/src/components/browse/dataset/datasetAccordion/datasetSummary/datasetFiles.tsx
@@ -36,8 +36,8 @@ const DatasetFiles = (props: DataSetFilesProps) => {
                 })}
               </ul>
               <p className="mb-0">
-                <strong>{parseBytes(props.files.stats?.size)}</strong> total
-                size
+                <strong>{parseBytes(props.files.stats?.size || 0)}</strong>{" "}
+                total size
               </p>
             </div>
           ) : (

--- a/src/components/home/fileStats.tsx
+++ b/src/components/home/fileStats.tsx
@@ -1,0 +1,33 @@
+import { MetadataSummaryModel, FileSummaryModel } from "../../models/dataset";
+
+/** Aggregate file stats for all files types. */
+export function aggregateFileStats(
+  summary: MetadataSummaryModel
+): FileSummaryModel {
+  const stats: {
+    [key: string]: FileSummaryModel;
+  } = summary.resource_stats as any;
+  const formats: { [format: string]: number } = {};
+  let count = 0;
+  let size = 0;
+  for (const statsName of Object.keys(stats).filter((key) =>
+    key.endsWith("File")
+  )) {
+    const fileSummary = stats[statsName];
+    count += fileSummary.count || 0;
+    size += fileSummary.stats?.size || 0;
+    for (const format of fileSummary.stats?.format || []) {
+      formats[format.value] = (formats[format.value] || 0) + format.count;
+    }
+  }
+  return {
+    count,
+    stats: {
+      format: Object.entries(formats).map(([value, count]) => ({
+        value,
+        count,
+      })),
+      size,
+    },
+  };
+}

--- a/src/components/home/homeMidSection/homeMidSection.tsx
+++ b/src/components/home/homeMidSection/homeMidSection.tsx
@@ -10,6 +10,7 @@ import { Col, Row } from "react-bootstrap";
 import { NavLink } from "react-router-dom";
 import { getMetadataSummary } from "../../../api/browse";
 import { MetadataSummaryModel } from "../../../models/dataset";
+import { aggregateFileStats } from "../fileStats";
 import HomeMidSectionBadge from "./homeMidSectionBadge";
 
 /** Section on the home  page where Statistics are listed in cards (badges). */
@@ -140,15 +141,13 @@ const HomeMidSection = () => {
       badgeDark: true,
     });
 
-    const processFiles = summary?.resource_stats?.SequencingProcessFile;
-    const numProcessFiles = processFiles?.count || 0;
-    const processFileFormats = processFiles?.stats?.format || [];
+    const fileStats = aggregateFileStats(summary);
     Badges.push({
-      badgeTitle: BadgeTitleGen(faChartColumn, "Files: " + numProcessFiles),
+      badgeTitle: BadgeTitleGen(faChartColumn, "Files: " + fileStats.count),
       badgeBody: (
         <table>
           <tbody>
-            {processFileFormats.map((x) => {
+            {fileStats.stats.format.map((x) => {
               return (
                 <tr key={x.value} className="text-uppercase ms-0 ps-0 mb-2">
                   <td

--- a/src/models/dataset.ts
+++ b/src/models/dataset.ts
@@ -240,8 +240,10 @@ export interface ProtocolSummaryModel {
 export interface MetadataSummaryModel {
   resource_stats: {
     Dataset: DatasetSummaryModel;
-    SequencingProcessFile: FileSummaryModel;
     Individual: IndividualSummaryModel;
     SequencingProtocol: ProtocolSummaryModel;
+    AnalysisProcessOutputFile: FileSummaryModel;
+    SequencingProcessFile: FileSummaryModel;
+    StudyFile: FileSummaryModel;
   };
 }


### PR DESCRIPTION
The Data Portal so far only showed the number of sequencing process files on the "Files" card in the summary section of the home page, and not the total number of all files.

This PR adds a function that aggregates the numbers for all file types, and this aggregated file summary is then used to display the number of files (total and per format) on the home page.