### PR TITLE
Adapt to support changes for basic auth in auth adapter

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -163,7 +163,7 @@ class AuthService {
     };
     let response = await fetchJson(LOGIN_URL, "POST", null, headers);
 
-    if (response.status === 401) {
+    if (response.status === 401 || response.status === 403) {
       let detail;
       try {
         detail = (await response.json()).detail;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -113,8 +113,11 @@ export const fetchJson = async (
   const body = payload ? JSON.stringify(payload) : undefined;
   try {
     const response = await fetch(url, { method, headers, body });
-    if (response.status === 403 && url !== LOGIN_URL && url !== LOGOUT_URL) {
-      // authentication error, check if session has expired
+    if (
+      (response.status === 401 || response.status === 403) &&
+      !(url === LOGIN_URL || url === LOGOUT_URL)
+    ) {
+      // authentication error: check if session has expired
       if (authService.getCurrentUser() && !(await authService.getUser(true))) {
         showMessage({
           type: "error",


### PR DESCRIPTION
Treat 401 and 403 responses the same, since the auth adapter can return both of them, depending on whether there is basic auth active on top of the OIDC/session/TOTP authentication.