### PR TITLE
Revert the docker base image update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-FROM node:lts-alpine3.20
+FROM node:lts-alpine3.18
 
 # update and install dependencies
 RUN apk update && apk upgrade


### PR DESCRIPTION
For some reason, updating the docker base image from alpine 3.18 to 3.20 fails in the `RUN python3 -m ensurepip`, so reverting this update for now. Should be investigated.