### PR TITLE
Remaining fixes with the latest metldata/mass changes

### DIFF
--- a/src/components/browse/singleDatasetView/singleDatasetViewAccordion/tables/experimentsTable.ts
+++ b/src/components/browse/singleDatasetView/singleDatasetViewAccordion/tables/experimentsTable.ts
@@ -25,7 +25,7 @@ export const ExperimentsTable = (props: ExperimentsTableProps) => {
     order: 0,
   });
 
-  const experiments = props.details.sequencing_experiments || [];
+  const experiments = props.details.experiments || [];
 
   const experimentsTable: TableFields[] = [
     {

--- a/src/components/browse/singleDatasetView/singleDatasetViewTabs/publicationTabContents.tsx
+++ b/src/components/browse/singleDatasetView/singleDatasetViewTabs/publicationTabContents.tsx
@@ -25,7 +25,7 @@ const PublicationTabContents = (props: PublicationTabContentsProps) => {
               return (
                 <div
                   key={pub.accession + "_pub"}
-                  className="text-break overflow-auto h-100"
+                  className="text-break overflow-auto h-100 mb-5"
                 >
                   {pub.doi !== null ? (
                     <Button

--- a/src/components/home/homeMidSection/homeMidSection.tsx
+++ b/src/components/home/homeMidSection/homeMidSection.tsx
@@ -105,7 +105,7 @@ const HomeMidSection = () => {
     });
 
     const protocolTypes =
-      summary?.resource_stats?.SequencingProtocol?.stats?.type || [];
+      summary?.resource_stats?.ExperimentMethod?.stats?.instrument_model || [];
     Badges.push({
       badgeTitle: BadgeTitleGen(faDna, "Platforms: " + protocolTypes.length),
       badgeBody: protocolTypes.map((x: any) => (

--- a/src/models/dataset.ts
+++ b/src/models/dataset.ts
@@ -45,7 +45,7 @@ export interface FileModel {
   format: string;
 }
 
-export interface SequencingExperimentEmbeddedModel {
+export interface ExperimentEmbeddedModel {
   title: string;
   sequencing_protocol: {
     instrument_model: string;
@@ -140,7 +140,7 @@ export interface DatasetEmbeddedModel {
   title: string;
   description: string;
   types: string[];
-  sequencing_experiments: SequencingExperimentEmbeddedModel[] | undefined;
+  experiments: ExperimentEmbeddedModel[] | undefined;
   study_files: FileModel[];
   sample_files: FileModel[];
   sequencing_process_files: FileModel[];
@@ -227,10 +227,10 @@ export interface IndividualSummaryModel {
   };
 }
 
-export interface ProtocolSummaryModel {
+export interface ExperimentMethodSummaryModel {
   count: number;
   stats: {
-    type: { value: string; count: number }[];
+    instrument_model: { value: string; count: number }[];
   };
 }
 
@@ -238,7 +238,7 @@ export interface MetadataSummaryModel {
   resource_stats: {
     Dataset: DatasetSummaryModel;
     Individual: IndividualSummaryModel;
-    SequencingProtocol: ProtocolSummaryModel;
+    ExperimentMethod: ExperimentMethodSummaryModel;
     AnalysisProcessOutputFile: FileSummaryModel;
     SequencingProcessFile: FileSummaryModel;
     StudyFile: FileSummaryModel;


### PR DESCRIPTION
- "Platforms" global stats is no longer empty
- In single dataset view:
  - "Publications" tab no longer empty
  - "Experiments" table no longer empty