### PR TITLE
Improve login behavior

### DIFF
--- a/src/components/confirm2FA/confirm2FA.tsx
+++ b/src/components/confirm2FA/confirm2FA.tsx
@@ -109,6 +109,8 @@ const Confirm2FA = () => {
     unblock();
     back();
   } else {
+    const has2fa = /HasTotpToken|Authenticated/.test(user?.state);
+
     const Lost2FAModal = (props: any) => {
       const [disabledNew2FAButton, setDisabledNew2FAButton] = useState(true);
       return (
@@ -242,7 +244,10 @@ const Confirm2FA = () => {
             </div>
           </form>
         </div>
-        <Modal show={blocked && blocker.state === "blocked"} onHide={stay}>
+        <Modal
+          show={!has2fa && blocked && blocker.state === "blocked"}
+          onHide={stay}
+        >
           <Modal.Header closeButton>
             <Modal.Title>You have not setup 2FA yet!</Modal.Title>
           </Modal.Header>

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -73,6 +73,10 @@ class AuthService {
     const settings = this.settings;
     this.userManager = new UserManager(settings);
 
+    // reset the user to force-fetch it via the session
+    // (may have been logged out in another session or due to timeout)
+    this.setUser(null);
+
     Log.setLogger(console);
     Log.setLevel(Log.INFO); // set to DEBUG for more output
   }


### PR DESCRIPTION
This helps when logging out in another browser tab:
- When the page is refreshed, check whether the session is still active.

This prevents a glitch that would sometimes erroneously show the 2fa setup dialog:
- On the 2FA confimation page, do not show the setup dialog if already set up.